### PR TITLE
feat(flake): migrate to mkSystemFlake; default fleet to unstable channel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1304,11 +1304,11 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1777303919,
-        "narHash": "sha256-y9vkh7MsKG0+TrZym1ME1oTzWl65A7BiLbbI0jDIgIA=",
+        "lastModified": 1777489457,
+        "narHash": "sha256-mZRX/FsrtIFo0M4uJ+d48PV0CvkgW3zPeSFmFG5BQ4Y=",
         "owner": "ncrmro",
         "repo": "keystone",
-        "rev": "849145513f956bb988b9c154c79093fc87e85b6b",
+        "rev": "565148cdd2011c5f8bb55eb538a308b4808c08c5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -58,18 +58,160 @@
           };
           overlays = overlays;
         };
+
+      # Module args (`inputs`, `self`, `outputs`) are passed to every host
+      # via mkSystemFlake's `shared.specialArgs`. They cannot be supplied via
+      # `_module.args` because consumer modules (e.g.
+      # modules/keystone/os.nix) reference `inputs.keystone.nixosModules.*`
+      # inside their own `imports` list, and `_module.args` resolution
+      # depends on `config`, which causes infinite recursion at import time.
+      fleetSpecialArgs = {
+        inherit inputs self;
+        outputs = self;
+      };
+
+      # Fleet admin user. mkSystemFlake places this at
+      # `keystone.os.users.<adminUsername>` with `admin = true`, so this is
+      # the single source of truth for the ncrmro identity. The matching
+      # block was removed from `modules/keystone/os.nix` during this migration.
+      adminUser = {
+        username = "ncrmro";
+        fullName = "Nicholas Romero";
+        terminal.enable = true;
+        capabilities = [
+          "ks"
+          "engineer"
+          "product"
+          "project-manager"
+          "notes"
+        ];
+      };
+
+      # Storage devices are managed entirely by per-host disko configs in this
+      # fleet (`keystone.os.storage.enable = false` in modules/keystone/os.nix).
+      # mkLaptop/mkServer still require a storage.devices list for option-type
+      # validation, so pass a placeholder. The keystone storage module is
+      # gated on `storage.enable`, so these values are never read at runtime.
+      placeholderDevices = [ "/dev/disk/by-id/placeholder-disko-managed" ];
+
+      # All hosts that have ZFS backups declared need `storage.type = "zfs"`
+      # to satisfy the keystone zfs-backup assertion, even when
+      # `storage.enable = false` (this fleet handles ZFS via per-host disko
+      # configs). mkLaptop's default of "ext4" trips the assertion on
+      # ncrmro-laptop, so override here.
+      zfsStorage = {
+        type = "zfs";
+        mode = "single";
+        devices = placeholderDevices;
+      };
+
+      fleet = inputs.keystone.lib.mkSystemFlake {
+        admin = adminUser;
+        defaults = {
+          timeZone = "America/Chicago";
+          # Channel default deliberately matches the keystone option default
+          # for now; a follow-up commit flips this to "unstable" so the fleet
+          # tracks main until a stable release exists.
+          updateChannel = "stable";
+        };
+        shared.specialArgs = fleetSpecialArgs;
+        hosts = {
+          maia = {
+            kind = "server";
+            stateVersion = "25.11";
+            # mkServer defaults to ZFS; placeholder devices are ignored
+            # because keystone.os.storage.enable = false in this fleet.
+            storage.devices = placeholderDevices;
+            modules = [ ./hosts/maia ];
+          };
+
+          ncrmro-laptop = {
+            kind = "laptop";
+            stateVersion = "25.11";
+            # Override mkLaptop's ext4 default — laptop runs ZFS via disko
+            # and the keystone zfs-backup module asserts `storage.type ==
+            # "zfs"` regardless of `storage.enable`.
+            storage = zfsStorage;
+            modules = [ ./hosts/ncrmro-laptop ];
+          };
+
+          mercury = {
+            kind = "server";
+            hostname = "mercury";
+            stateVersion = "25.05";
+            storage.devices = placeholderDevices;
+            # Mercury is a VPS without TPM or Secure Boot hardware. The
+            # host module turns those off, so mkSystemFlake's defaults
+            # (which would force them on) must match here too.
+            secureBoot.enable = false;
+            tpm.enable = false;
+            # Mercury reads ocean's generated DNS/ACL records as a specialArg.
+            # The reference into `fleet.nixosConfigurations.ocean` is lazy:
+            # ocean's config is only forced when mercury's modules actually
+            # read `oceanConfig`, so there is no evaluation-time recursion.
+            specialArgs = {
+              oceanConfig = fleet.nixosConfigurations.ocean.config;
+            };
+            modules = [ ./hosts/mercury ];
+          };
+
+          # catalystPrimary is a non-keystone host (k3s VPS with hardcoded
+          # SSH keys; see hosts/catalystPrimary/default.nix). It does NOT
+          # import any keystone modules and does NOT want mkSystemFlake's
+          # mkServer wrapper to force `keystone.os.enable = true` onto it.
+          # This host is wired manually below the mkSystemFlake call as a
+          # documented exception — see `nixosConfigurations.catalystPrimary`
+          # at the end of the outputs block.
+
+          ocean = {
+            kind = "server";
+            stateVersion = "25.11";
+            storage.devices = placeholderDevices;
+            modules = [ ./hosts/ocean ];
+          };
+
+          ncrmro-workstation = {
+            # `workstation` is a distinct mkSystemFlake kind — it pre-pins a
+            # ZFS-compatible kernel and enables the desktop archetype, which
+            # is what this host wants.
+            kind = "workstation";
+            stateVersion = "25.11";
+            storage.devices = placeholderDevices;
+            modules = [ ./hosts/workstation ];
+          };
+        };
+      };
     in
-    {
+    fleet
+    // {
+      # `catalystPrimary` is wired manually as an exception: it does not use
+      # the keystone OS module (k3s VPS, hardcoded SSH keys), so wrapping it
+      # via mkSystemFlake would force `keystone.os.enable = true` and trip
+      # the storage / fileSystems assertions. Merging into nixosConfigurations
+      # via attribute-set extension keeps it discoverable alongside the rest.
+      nixosConfigurations = fleet.nixosConfigurations // {
+        catalystPrimary = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [ ./hosts/catalystPrimary ];
+          specialArgs = {
+            inherit inputs self;
+            outputs = self;
+          };
+        };
+      };
+
       # Code formatter (official NixOS formatter)
       formatter.x86_64-linux = (pkgsForSystem "x86_64-linux").nixfmt;
       formatter.aarch64-darwin = (pkgsForSystem "aarch64-darwin").nixfmt;
 
-      # Custom packages
+      # Custom packages — extend whatever mkSystemFlake exposes (e.g.
+      # installerTargetsJson, vm-image-*, iso) with our own.
       packages.x86_64-linux =
         let
           pkgs = pkgsForSystem "x86_64-linux";
         in
-        {
+        (fleet.packages.x86_64-linux or { })
+        // {
           inherit (pkgs.keystone)
             claude-code
             codex
@@ -79,69 +221,15 @@
           inherit (pkgs) mcp-language-server;
 
           # Installer ISO — keys auto-collected from keystone.os.users (wheel) + hardware root keys
-          iso = self.nixosConfigurations.ncrmro-workstation.config.keystone.os.installer.isoImage;
+          iso = fleet.nixosConfigurations.ncrmro-workstation.config.keystone.os.installer.isoImage;
         };
 
       # Import NixOS and Home Manager modules
       nixosModules = import ./modules/nixos;
       homeManagerModules = import ./modules/home-manager;
 
-      # NixOS system configurations
-      nixosConfigurations = {
-        # Home server configuration
-        maia = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [ ./hosts/maia ];
-          specialArgs = {
-            inherit inputs self;
-            outputs = self;
-          };
-        };
-
-        ncrmro-laptop = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [ ./hosts/ncrmro-laptop ];
-          specialArgs = {
-            inherit inputs self;
-            outputs = self;
-          };
-        };
-        mercury = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [ ./hosts/mercury ];
-          specialArgs = {
-            inherit inputs self;
-            outputs = self;
-            oceanConfig = self.nixosConfigurations.ocean.config;
-          };
-        };
-        catalystPrimary = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [ ./hosts/catalystPrimary ];
-          specialArgs = {
-            inherit inputs self;
-            outputs = self;
-          };
-        };
-        ocean = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [ ./hosts/ocean ];
-          specialArgs = {
-            inherit inputs self;
-            outputs = self;
-          };
-        };
-        ncrmro-workstation = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [ ./hosts/workstation ];
-          specialArgs = {
-            inherit inputs self;
-            outputs = self;
-          };
-        };
-      };
-
-      # Home Manager configurations
+      # macOS Home Manager configurations — mkSystemFlake doesn't manage these
+      # because macOS hosts here are user-only, not full system flakes.
       homeConfigurations = {
         "nicholas@unsup-macbook" = home-manager.lib.homeManagerConfiguration {
           modules = [ ./home-manager/ncrmro/unsup-macbook.nix ];

--- a/flake.nix
+++ b/flake.nix
@@ -109,10 +109,11 @@
         admin = adminUser;
         defaults = {
           timeZone = "America/Chicago";
-          # Channel default deliberately matches the keystone option default
-          # for now; a follow-up commit flips this to "unstable" so the fleet
-          # tracks main until a stable release exists.
-          updateChannel = "stable";
+          # Default the entire fleet to the unstable update channel.
+          # Until ncrmro/keystone publishes a GitHub release, the stable
+          # channel cannot resolve (404), so unstable is the only working
+          # default. Per-host opt-back-in via `updateChannel = "stable"`.
+          updateChannel = "unstable";
         };
         shared.specialArgs = fleetSpecialArgs;
         hosts = {

--- a/modules/keystone/desktop.nix
+++ b/modules/keystone/desktop.nix
@@ -7,7 +7,13 @@
 {
   imports = [
     inputs.home-manager.nixosModules.default
-    inputs.keystone.nixosModules.desktop
+    # `keystone.nixosModules.desktop` is imported automatically by
+    # mkSystemFlake when `kind = laptop` or `kind = workstation`. Re-importing
+    # it here from `inputs.keystone.nixosModules.desktop` produces a second
+    # inline-attrset instance that NixOS does not deduplicate; the desktop
+    # module's `home-manager.sharedModules = [ self.homeModules.desktop ]`
+    # then runs twice and triggers `programs.walker.elephant` "already
+    # declared" errors during home-manager evaluation.
   ];
 
   users.mutableUsers = true;

--- a/modules/keystone/os.nix
+++ b/modules/keystone/os.nix
@@ -2,14 +2,20 @@
 # Every machine in the fleet imports this module.
 { inputs, lib, ... }:
 {
+  # `keystone.nixosModules.operating-system` is imported automatically by
+  # mkSystemFlake (via mkLinuxHost). Re-importing it here from
+  # `inputs.keystone.nixosModules.operating-system` produces a second
+  # _file-less inline-attrset module instance that NixOS does not
+  # deduplicate; sharedModules entries get applied twice and trigger
+  # `_module.args.keystoneInputs` "defined multiple times" errors.
+  #
+  # `keystone.nixosModules.{domain,services,hosts}` are already pulled in
+  # by `operating-system`'s own imports list (see keystone flake.nix), so
+  # they don't need to be repeated either.
   imports = [
-    inputs.keystone.nixosModules.operating-system
     inputs.keystone.nixosModules.hardwareKey
     inputs.keystone.nixosModules.keys
     inputs.keystone.nixosModules.binaryCacheClient
-    inputs.keystone.nixosModules.domain
-    inputs.keystone.nixosModules.services
-    inputs.keystone.nixosModules.hosts
     ../keys.nix
     ../../hosts/common/global/openssh.nix
     ../../hosts/common/agent-identities.nix
@@ -66,23 +72,16 @@
     storage.enable = lib.mkDefault false; # All hosts use disko
     ssh.enable = lib.mkDefault false; # SSH configured independently
     hypervisor.enable = lib.mkDefault true;
-    users.ncrmro = {
-      admin = true;
-      fullName = "Nicholas Romero";
-      # Supplementary groups are module-owned post-#470/#471:
-      #   wheel, podman, libvirtd, dialout, media → admin (this user)
-      #   networkmanager, video, audio           → desktop users (via desktop.enable)
-      #   zfs                                    → all users on ZFS storage
-      # Retired groups: input, sound, docker (see keystone process.user-groups).
-      terminal.enable = lib.mkDefault true;
-      capabilities = [
-        "ks"
-        "engineer"
-        "product"
-        "project-manager"
-        "notes"
-      ];
-    };
+    # The admin user (ncrmro) is now declared in flake.nix `adminUser` and
+    # threaded through `mkSystemFlake { admin = ...; }`. Keep per-host
+    # tweaks (e.g. desktop.enable on workstation/laptop) in their own modules;
+    # do not redeclare the admin user here.
+    #
+    # Supplementary groups are module-owned post-#470/#471:
+    #   wheel, podman, libvirtd, dialout, media → admin (this user)
+    #   networkmanager, video, audio           → desktop users (via desktop.enable)
+    #   zfs                                    → all users on ZFS storage
+    # Retired groups: input, sound, docker (see keystone process.user-groups).
   };
 
   keystone.secrets.repo = inputs.agenix-secrets;

--- a/modules/keystone/server.nix
+++ b/modules/keystone/server.nix
@@ -1,9 +1,11 @@
 # NixOS: server role — enables keystone server module.
-{ inputs, ... }:
+#
+# `keystone.nixosModules.server` is imported automatically by mkSystemFlake
+# when `kind = server` (see mkLinuxHost / linuxKindDefaults). We do not
+# re-import it here to keep the desktop/operating-system pattern consistent
+# (a second inline-attrset instance is not deduplicated by NixOS and
+# duplicates downstream `home-manager.sharedModules` entries).
+{ ... }:
 {
-  imports = [
-    inputs.keystone.nixosModules.server
-  ];
-
   keystone.server.enable = true;
 }


### PR DESCRIPTION
## Summary

Migrate `nixos-config` to `keystone.lib.mkSystemFlake` so fleet-wide settings (admin identity, time zone, update channel) live at the call site instead of being threaded into every host's module list. Default the entire fleet to the `unstable` update channel — `keystone` has no published GitHub release yet, so `stable` cannot resolve and Walker → Update is broken until either a release lands or the fleet flips to unstable.

`Closes #23`.

This PR is **blocked on ncrmro/keystone#490** (a small `mkSystemFlake` extension that adds per-host `specialArgs` support). Once that lands, the lock can be moved back to a `main` commit; today the lock points at the keystone PR's commit so this branch can build.

## Commits

1. `chore(deps): lock keystone to feat/mkSystemFlake-special-args` — `flake.lock`. Pulls in the keystone-side change so `mkSystemFlake` exposes `shared.specialArgs`.
2. `refactor(flake): migrate hosts to keystone.lib.mkSystemFlake` — flake.nix port + module-hygiene cleanups in `modules/keystone/{os,desktop,server}.nix`.
3. `feat(flake): default fleet updateChannel to "unstable"` — one-line flip at the `defaults.updateChannel` call site.

## Friction & schema deviations

- **Per-host `specialArgs`** — every host module uses the `{ inputs, outputs, ... }:` pattern and references `inputs.keystone.nixosModules.*` inside `imports = [ ... ]`. `mkLinuxHost` previously did not pass `specialArgs`, so `_module.args` was the only fallback — and that triggers an infinite-recursion error at module-import time. Filed as ncrmro/keystone#490 (Option A in the issue contingency), which adds `shared.specialArgs` and per-host `hosts.<name>.specialArgs` to mkSystemFlake.
- **`mercury.specialArgs.oceanConfig`** — mercury's `headscale-dns` module reads `oceanConfig.keystone.server.generatedDNSRecords` etc. Threaded through the new per-host `specialArgs` field; the lazy reference into `fleet.nixosConfigurations.ocean.config` does not cause evaluation-time recursion because it is only forced when mercury's modules read `oceanConfig`.
- **`catalystPrimary` is wired manually** — that host (k3s VPS, hardcoded SSH keys) does not import any keystone modules, so wrapping it via `mkServer` would force `keystone.os.enable = true` and trip the storage / fileSystems assertions. It is kept outside `mkSystemFlake.hosts` and merged in as `nixosConfigurations.catalystPrimary // ...` (Option B in the contingency). This is the only host that does not flow through mkSystemFlake.
- **`ncrmro-laptop` storage** — laptop runs ZFS via per-host disko (`keystone.os.storage.enable = false`), but the keystone zfs-backup module's assertion fires on `osCfg.storage.type` regardless of `storage.enable`. Override `storage = { type = "zfs"; mode = "single"; devices = placeholderDevices; }` at the mkSystemFlake call site to satisfy the assertion.
- **`mercury.{secureBoot,tpm}` opt-out** — mercury (Vultr VPS) has no TPM and no Secure Boot. Set both to `enable = false` at the mkSystemFlake call site to match the existing host-module overrides; equality merging fails when defaults differ.
- **Module-hygiene cleanups** — NixOS does not deduplicate inline-attrset modules without `_file`. Removed redundant explicit imports of `keystone.nixosModules.{operating-system,desktop,server}` from `modules/keystone/{os,desktop,server}.nix` because `mkLinuxHost` now imports those automatically. Without these removals the desktop sharedModules ran twice and triggered `programs.walker.elephant` "already declared" errors; the operating-system module's `_module.args.keystoneInputs` ended up "defined multiple times" on agent users.

## Verification

| Host | `nix build` (toplevel) | `keystone.update.channel` | `home-manager.users.ncrmro.keystone.update.channel` |
|------|------------------------|---------------------------|------------------------------------------------------|
| `maia` | ❌ pre-existing zfs-backup conflict | `"unstable"` | `"unstable"` |
| `ncrmro-laptop` | ✅ builds | `"unstable"` | `"unstable"` |
| `mercury` | ✅ dry-run passes | `"unstable"` | `"unstable"` |
| `catalystPrimary` | ✅ dry-run passes | n/a (host doesn't import keystone) | n/a |
| `ocean` | ❌ pre-existing zfs-backup conflict | `"unstable"` | `"unstable"` |
| `ncrmro-workstation` | ✅ dry-run passes | `"unstable"` | `"unstable"` |

The two failures (`maia`, `ocean`) reproduce on `master` at the same lock — the `users.users.<host>-sync.group` conflict is between `hosts/common/optional/zfs.backup.nix` (sets `"zfs-sync"`) and `keystone/modules/os/zfs-backup.nix` (sets `"<host>-sync"`). Independent of this migration; tracked separately.

## Relationship to other PRs

- **ncrmro/keystone#490** — blocks this PR. Adds `specialArgs` support to `mkSystemFlake`. Cannot land here without it.
- **ncrmro/keystone#488** — supervised `ks update` flow. PR #488 needs a resolvable channel to install something, which is exactly what `defaults.updateChannel = "unstable"` provides today (until a stable release lands).

## Test plan

- [x] `nix eval .#nixosConfigurations.<host>.config.keystone.update.channel` returns `"unstable"` on every keystone-managed host.
- [x] `nix eval .#nixosConfigurations.<host>.config.home-manager.users.ncrmro.keystone.update.channel` returns `"unstable"` on every keystone-managed host.
- [x] `nix build .#nixosConfigurations.ncrmro-laptop.config.system.build.toplevel` succeeds.
- [x] Dry-run builds succeed for `mercury`, `catalystPrimary`, `ncrmro-workstation`.
- [ ] After ncrmro/keystone#490 merges, run `nix flake update keystone` here and confirm builds remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)