### PR TITLE
feat(observability): add OX node Prometheus scrape target

### DIFF
--- a/hosts/ocean/observability/prometheus.nix
+++ b/hosts/ocean/observability/prometheus.nix
@@ -106,6 +106,20 @@ in
                 device_type = "plant-monitor";
               };
             }
+            # TODO: 192.168.1.148 is currently a DHCP lease; a renewal could move
+            # the OX node to a different address and silently break this scrape.
+            # Pin it via either a `wifi.manual_ip` block in
+            # ncrmro/plant-caravan:hardware/firmware/ox-node.yaml or a DHCP
+            # reservation in adguard-home.nix.
+            {
+              targets = [ "192.168.1.148:80" ];
+              labels = {
+                instance = "ox-node";
+                environment = "home";
+                device_type = "ox-node";
+                subsystem = "power";
+              };
+            }
           ];
         }
       ];


### PR DESCRIPTION
## Summary

- Add `192.168.1.148:80` (OX outdoor node) to the existing `iot` job in ocean's Prometheus scrape config.
- Introduce a new `subsystem = "power"` label to distinguish the OX node's solar/battery telemetry from the existing seed-incubator and plant-monitor sensor devices.
- TODO comment notes the IP is currently a DHCP lease; should be pinned later via either a `wifi.manual_ip` block in `ncrmro/plant-caravan:hardware/firmware/ox-node.yaml` or a DHCP reservation in `adguard-home.nix`.

## Test plan

- [x] `nixfmt` clean (formatting matches surrounding blocks).
- [x] `nix build .#nixosConfigurations.ocean.config.system.build.toplevel --no-link` succeeds.
- [x] `nix eval` confirms the third `static_configs` entry is rendered into the final scrape config.
- [ ] After deploy, `curl http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | select(.labels.instance=="ox-node")'` shows the target as `up`.