### PR TITLE
feat(grafana): provision OX outdoor node dashboard

### DIFF
--- a/hosts/ocean/observability/dashboards/ox-node.json
+++ b/hosts/ocean/observability/dashboards/ox-node.json
@@ -1,0 +1,524 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["plant-caravan", "ox-node", "power"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "label": "Data source",
+        "query": "prometheus",
+        "regex": "",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "refresh": 1,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "OX Outdoor Node — Power & Telemetry",
+  "uid": "ox-node-power-telemetry",
+  "version": 1,
+  "weekStart": "",
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "About",
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "options": {
+        "mode": "markdown",
+        "content": "**OX Outdoor Node** — battery and inferred-solar telemetry from the bench/outdoor ESP32-C3 carrier. Caveats:\n- The dV/dt-derived metrics (`Net current`, `Solar input *`, `Time to empty/full`) are honest only in the linear region of the LiPo curve (~3.5–4.0 V).\n- `Solar input current` adds an assumed `system_load_ma` constant (currently a 5 mA placeholder) — recalibrate via a USB-disconnect, no-solar discharge run.\n- See [the spike post](/d/...) (link tbd) and `hardware/firmware/ox-node.yaml` in plant-caravan for the math."
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Battery state",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 3 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_text_sensor_value{id=\"battery_state\",instance=\"ox-node\"}",
+          "instant": true,
+          "legendFormat": "{{value}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "charging": { "text": "charging", "color": "green", "index": 0 } } },
+            { "type": "value", "options": { "float": { "text": "float", "color": "green", "index": 1 } } },
+            { "type": "value", "options": { "idle": { "text": "idle", "color": "blue", "index": 2 } } },
+            { "type": "value", "options": { "discharging": { "text": "discharging", "color": "orange", "index": 3 } } },
+            { "type": "value", "options": { "unknown": { "text": "unknown", "color": "text", "index": 4 } } }
+          ],
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null }
+            ]
+          },
+          "noValue": "—"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "/.*value.*/", "values": false },
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Battery voltage",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 3 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"battery_voltage\",instance=\"ox-node\"}",
+          "instant": false,
+          "legendFormat": "Vbatt",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt",
+          "decimals": 3,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 3.45 },
+              { "color": "yellow", "value": 3.65 },
+              { "color": "green", "value": 3.85 }
+            ]
+          },
+          "noValue": "—"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Net current",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 3 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"battery_net_current\",instance=\"ox-node\"}",
+          "instant": false,
+          "legendFormat": "Net",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "milliamp",
+          "decimals": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": -50 },
+              { "color": "green", "value": 0 }
+            ]
+          },
+          "noValue": "—"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "WiFi signal",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 3 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"wifi_signal\",instance=\"ox-node\"}",
+          "instant": false,
+          "legendFormat": "RSSI",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dBm",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": -80 },
+              { "color": "green", "value": -70 }
+            ]
+          },
+          "noValue": "—"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Battery voltage",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"battery_voltage\",instance=\"ox-node\"}",
+          "legendFormat": "Vbatt",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt",
+          "decimals": 3,
+          "min": 3.0,
+          "max": 4.3,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "auto",
+            "pointSize": 4,
+            "spanNulls": true,
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 3.20 },
+              { "color": "yellow", "value": 3.45 },
+              { "color": "green", "value": 4.18 },
+              { "color": "blue", "value": 4.20 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "min", "max"] }
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "dV/dt rate",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"battery_voltage_rate\",instance=\"ox-node\"}",
+          "legendFormat": "dV/dt",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "V/h",
+          "decimals": 4,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "auto",
+            "pointSize": 4,
+            "spanNulls": true,
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "text", "value": 0 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "min", "max"] }
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Battery net current vs solar input current",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"battery_net_current\",instance=\"ox-node\"}",
+          "legendFormat": "Net (battery)",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"solar_input_current\",instance=\"ox-node\"}",
+          "legendFormat": "Solar input (estimated)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "milliamp",
+          "decimals": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "auto",
+            "pointSize": 4,
+            "spanNulls": true,
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "text", "value": 0 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "min", "max"] }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Solar input power",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"solar_input_power\",instance=\"ox-node\"}",
+          "legendFormat": "Solar input power",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "milliwatts",
+          "decimals": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "auto",
+            "pointSize": 4,
+            "spanNulls": true
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "min", "max"] }
+      }
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "Time to empty",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 23 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"battery_time_to_empty\",instance=\"ox-node\"}",
+          "legendFormat": "TTE",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "hours",
+          "decimals": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 12 },
+              { "color": "green", "value": 48 }
+            ]
+          },
+          "noValue": "—"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Time to full",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 23 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"battery_time_to_full\",instance=\"ox-node\"}",
+          "legendFormat": "TTF",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "hours",
+          "decimals": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "blue", "value": 2 },
+              { "color": "text", "value": 8 }
+            ]
+          },
+          "noValue": "—"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Uptime",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 27 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "esphome_sensor_value{id=\"uptime\",instance=\"ox-node\"}",
+          "legendFormat": "Uptime",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dtdurations",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null }
+            ]
+          },
+          "noValue": "—"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal"
+      }
+    }
+  ]
+}

--- a/hosts/ocean/observability/dashboards/ox-node.json
+++ b/hosts/ocean/observability/dashboards/ox-node.json
@@ -279,7 +279,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "esphome_sensor_value{id=\"battery_voltage_rate\",instance=\"ox-node\"}",
+          "expr": "esphome_sensor_value{id=\"battery_v_rate\",instance=\"ox-node\"}",
           "legendFormat": "dV/dt",
           "refId": "A"
         }
@@ -412,7 +412,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "esphome_sensor_value{id=\"battery_time_to_empty\",instance=\"ox-node\"}",
+          "expr": "esphome_sensor_value{id=\"battery_tte\",instance=\"ox-node\"}",
           "legendFormat": "TTE",
           "refId": "A"
         }
@@ -452,7 +452,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "esphome_sensor_value{id=\"battery_time_to_full\",instance=\"ox-node\"}",
+          "expr": "esphome_sensor_value{id=\"battery_ttf\",instance=\"ox-node\"}",
           "legendFormat": "TTF",
           "refId": "A"
         }

--- a/hosts/ocean/observability/grafana.nix
+++ b/hosts/ocean/observability/grafana.nix
@@ -35,6 +35,10 @@
             hash = "sha256-1DE1aaanRHHeCOMWDGdOS1wBXxOF84UXAjJzT5Ek6mM=";
           };
         }
+        {
+          name = "ox-node.json";
+          path = ./dashboards/ox-node.json;
+        }
       ];
     }
   ];


### PR DESCRIPTION
## Summary

Provision a Grafana dashboard for the OX outdoor node and wire it into the existing `nixos-dashboards` `linkFarm` next to `node-exporter-full.json`.

Depends on #25 (`feat(observability): add OX node Prometheus scrape target`) — that PR makes `instance="ox-node"` series scrapable; this PR consumes them.

## Panels

- Row 1 — current state (4 stat panels): Battery state (text), Battery voltage (V), Net current (mA), WiFi signal (dBm).
- Row 2 — voltage & rate over time (2 timeseries): Battery voltage (with 4 threshold lines at 4.20/4.18/3.45/3.20), dV/dt rate (V/h, zero line).
- Row 3 — current & power over time (2 timeseries): Battery net current vs solar input current (mA, zero line); Solar input power (mW).
- Row 4 — runtime estimates (2 stat panels): Time to empty (hours), Time to full (hours). Both fall back to `—` when not publishing.
- Row 5 — diagnostics (1 stat panel): Uptime (`dtdurations`).
- Plus a markdown text panel at the top documenting caveats.

## Caveats baked into the dashboard text panel

- `Net current`, `Solar input *`, and `Time to empty/full` are derived from dV/dt and are honest only in the linear region of the LiPo curve (~3.5–4.0 V).
- `Solar input current` adds an assumed `system_load_ma` constant (currently a 5 mA placeholder) — recalibrate via a USB-disconnect, no-solar discharge run.
- The post link in the markdown panel is left as `(/d/...)` placeholder until a follow-up dashboard for the spike write-up exists.

## Folder placement (follow-up)

The OX folder UID `cfcjwozvj1hxcf` (Plant Caravan) was visible in the user's URL but is **not** used here. Moving the dashboard into that folder needs either a Grafana API token at provision time (so the provisioner can resolve the folder UID) or a manual move via UI. Left as a follow-up — the dashboard provisions to the default folder and can be moved from the UI.

## Notes

- Data source uses the `${DS_PROMETHEUS}` template variable so the JSON is portable across Grafana instances; a `templating` block declares it as a `datasource` query of type `prometheus`.
- Default refresh `30s`, default time range `now-6h`.
- Every query is filtered by `instance="ox-node"` so the dashboard is OX-only.
- The orphan `hosts/ocean/observability/dashboards/zfs-backup.json` already on disk is **not** touched by this PR — it's pre-existing technical debt and is unrelated.

## Test plan

- [x] `jq . hosts/ocean/observability/dashboards/ox-node.json` parses cleanly (12 panels).
- [x] `nixfmt` clean on `hosts/ocean/observability/grafana.nix`.
- [x] `nix build .#nixosConfigurations.ocean.config.system.build.toplevel --no-link` succeeds.
- [x] `nix eval` of `services.grafana.provision.dashboards.settings.providers` rendered to a `linkFarm` containing both `node-exporter-full.json` and `ox-node.json`.
- [ ] After deploy, dashboard is visible in Grafana at `/dashboards`, all panels render against live OX series.
- [ ] Manually move dashboard into the Plant Caravan folder (UID `cfcjwozvj1hxcf`) via UI — or follow up with a provisioner-level fix.