### PR TITLE
feat(home-manager/ncrmro): wire drago persona via keystone.terminal.agents

### DIFF
--- a/agents/drago.md
+++ b/agents/drago.md
@@ -1,4 +1,7 @@
-# drago — nixos-config agent instructions
+---
+name: drago
+description: Engineering persona for ncrmro/nixos-config work. Invoke for tasks in this repo when the standing rules apply — end-of-session PR comment audits and new-worktree direnv discipline.
+---
 
 Per-agent overlay loaded on top of the repo-wide `nixos-config/AGENTS.md`
 and the keystone conventions cascade. Rules here are drago-specific

--- a/flake.lock
+++ b/flake.lock
@@ -1288,11 +1288,11 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1778337398,
-        "narHash": "sha256-0A/7yrgpNhJWKuCQPj9dkBk5e3ZiN8cW3FLxF4Hr5nI=",
+        "lastModified": 1778606144,
+        "narHash": "sha256-+kRjtMMG3e+ajdGxeEi7Xz+2IIxFXcOxWERmJ0CLkGk=",
         "owner": "ncrmro",
         "repo": "keystone",
-        "rev": "06bf41516478e62ba45749f82df044196e75b649",
+        "rev": "29223c3ddcee22a3e29cf0fd6137485c5f7473bf",
         "type": "github"
       },
       "original": {

--- a/home-manager/ncrmro/base.nix
+++ b/home-manager/ncrmro/base.nix
@@ -94,4 +94,11 @@
   keystone.terminal.calendar.enable = true;
   keystone.terminal.contacts.enable = true;
   keystone.terminal.timer.enable = true;
+
+  keystone.terminal.agents = {
+    enable = true;
+    definitions = {
+      drago = ../../agents/drago.md;
+    };
+  };
 }


### PR DESCRIPTION
## Summary

- Adds Claude Code subagent frontmatter (`name`, `description`) to the drago persona and renames `agents/drago/AGENTS.md` → `agents/drago.md` so it conforms to the format `keystone.terminal.agents.definitions` consumes.
- Wires the persona into the new option in `home-manager/ncrmro/base.nix`. After deploy, drago is discoverable as a native subagent at `~/.claude/agents/drago.md` and `~/.copilot/agents/drago.md`.

## Dependency

Depends on **ncrmro/keystone#521** (`feat(terminal): add experimental agents home-manager module`) landing on `main`. Before merging this PR, the consumer flake must be relocked against post-merge keystone main: `nix flake update keystone`.

## Validation

```
nix eval --override-input keystone path:~/.worktrees/ncrmro/keystone/feat-terminal-agents \
  '.#nixosConfigurations.ncrmro-workstation.config.home-manager.users.ncrmro.keystone.terminal.agents'
# → {"definitions":{"drago":"/nix/store/...-source/agents/drago.md"},"enable":true}
```

Both `home.file.".claude/agents/drago.md".source` and `home.file.".copilot/agents/drago.md".source` resolve to the same store path.

## Test plan

- [ ] Keystone #521 merged to main
- [ ] `nix flake update keystone` in nixos-config, lock points at merged commit
- [ ] `ks build` succeeds
- [ ] `ks update --lock ncrmro-workstation` deploys
- [ ] `ls ~/.claude/agents/drago.md ~/.copilot/agents/drago.md` both resolve to a Nix store source
- [ ] Claude Code lists drago as an available subagent in a fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)