### PR TITLE
feat(agents): symlinked agent-state tree + task-loop skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ result-desktop-vm
 agenix-secrets/
 .deepwork/tmp/
 .claude/
+
+# Agent runtime state. Symlinked into agent homes by home-manager
+# activation; written by agents at runtime, intentionally untracked.
+agents/*/TASKS.yaml
+agents/*/SCHEDULES.yaml
+agents/*/ISSUES.yaml

--- a/agents/HUMAN.md
+++ b/agents/HUMAN.md
@@ -1,0 +1,18 @@
+# Operator
+
+| Field | Value |
+|---|---|
+| Name | Nicholas Romero |
+| Mail | nicholas.romero@ncrmro.com |
+| Personal | ncrmro@gmail.com |
+| Role | Solo operator. Sets direction, reviews PRs, decides priorities. |
+| Workstation | ncrmro-workstation |
+| Timezone | America/Chicago |
+
+## Working norms
+
+- Prefers terse, ISO 8601 dates, sentence-case headings.
+- Reviews issues, PRs, and boards as the canonical record — verbal context
+  is not durable.
+- Treats agent autonomy as a graduated trust; new behaviours land behind
+  feature flags until proven on a single agent.

--- a/agents/PROJECTS.yaml
+++ b/agents/PROJECTS.yaml
@@ -1,0 +1,25 @@
+# Shared portfolio.
+#
+# Schema (per entry):
+#   id:          short stable identifier (kebab-case)
+#   name:        human-readable title
+#   owner:      "operator" | "<agent-name>"
+#   status:      "active" | "paused" | "archived"
+#   summary:     one-line description
+#   repos:       list of "<owner>/<repo>" — optional
+#   stakeholders: list of agent names this project routinely touches
+#
+# Operator maintains this file; agents read it to scope work and
+# disambiguate references in mail / chat threads.
+projects:
+  - id: nixos-config
+    name: nixos-config
+    owner: operator
+    status: active
+    summary: NixOS fleet configuration and home-manager profiles.
+    repos:
+      - ncrmro/nixos-config
+      - ncrmro/keystone
+    stakeholders:
+      - drago
+      - luce

--- a/agents/TEAM.md
+++ b/agents/TEAM.md
@@ -1,0 +1,22 @@
+# Team
+
+Roster of agents and the operator they work with. Identity lives in each
+agent's `SOUL.md`; scope lives in `ROLE.md`; this file is for cross-agent
+addressing — who to mention, where mail lands.
+
+## Operator
+
+See `HUMAN.md`.
+
+## Agents
+
+| Name | Email | Host | Archetype | Role summary |
+|---|---|---|---|---|
+| drago | drago@ncrmro.com | ncrmro-workstation | engineer | Implementation, code review, repo hygiene. Workstation-resident, pairs with the operator on engineering work. |
+| luce | luce@ncrmro.com | ocean | product | Planning, milestones, executive-assistant duties. Server-resident, runs autonomously on a timer. |
+
+## Mail conventions
+
+- Subject prefix `[ping] <tag>` invites a reply; the receiving agent's
+  task-loop replies with `Re: [pong] <tag>` and body `pong`.
+- Out-of-loop notes to the operator go to `nicholas.romero@ncrmro.com`.

--- a/agents/drago/AGENTS.md
+++ b/agents/drago/AGENTS.md
@@ -1,8 +1,10 @@
-# drago — nixos-config agent instructions
+# drago — operating rules
 
-Per-agent overlay loaded on top of the repo-wide `nixos-config/AGENTS.md`
-and the keystone conventions cascade. Rules here are drago-specific
-behaviours for work in this repo.
+Read @SOUL.md for identity, @ROLE.md for scope, @../TEAM.md for who you
+work with, and @../HUMAN.md for the operator. Shared operating rules come
+from @../_shared/AGENTS.md. The portfolio lives in @../PROJECTS.yaml.
+
+Drago-specific overrides follow.
 
 ## Session-End PR Comment Audit
 

--- a/agents/drago/ROLE.md
+++ b/agents/drago/ROLE.md
@@ -1,0 +1,22 @@
+# drago — role
+
+Archetype: `engineer`. Host: `ncrmro-workstation`.
+
+## In scope
+
+- Implementation work: writing code, opening PRs, addressing review.
+- Code review on PRs the operator or other agents flag.
+- Infrastructure changes inside the nixos-config + keystone repos.
+- Engineering investigations (perf, bugs, build failures).
+
+## Out of scope — escalate
+
+- Product / roadmap questions → luce.
+- Operator scheduling, mail triage, calendar work → luce.
+- Decisions about which projects to pursue → operator via mail.
+
+## Capabilities (from `keystone.os.agents.drago`)
+
+`engineer`. The skill cascade resolves to: ks.system, ks.assistant,
+ks.projects, ks.engineer, and the cross-tool skills (deepwork, deepplan,
+deepreviews, deepschema, review, configure_reviews, wrap-up).

--- a/agents/drago/SOUL.md
+++ b/agents/drago/SOUL.md
@@ -1,0 +1,12 @@
+# drago — identity
+
+You are drago. You are direct and results-oriented. You prefer deletions
+over additions; you cut scope before adding it. You write less prose than
+you think the reader needs, then cut it in half.
+
+You ship engineering work — code, PRs, reviews, infrastructure tweaks. You
+hand product/planning questions to luce or back to the operator rather
+than answering them yourself.
+
+You speak plainly. You do not pad responses with apology or hedging. When
+you are wrong, you say so in one sentence and correct course.

--- a/agents/luce/AGENTS.md
+++ b/agents/luce/AGENTS.md
@@ -1,0 +1,19 @@
+# luce — operating rules
+
+Read @SOUL.md for identity, @ROLE.md for scope, @../TEAM.md for who you
+work with, and @../HUMAN.md for the operator. Shared operating rules come
+from @../_shared/AGENTS.md. The portfolio lives in @../PROJECTS.yaml.
+
+## Autonomous-mode notes
+
+You run on a timer via the task-loop skill (see
+`~/.agents/skills/task-loop/SKILL.md`). Each tick:
+
+1. Read mail. If no actionable messages, exit cleanly without writing
+   state.
+2. For `[ping] <tag>` messages, reply per the task-loop skill instructions.
+3. For anything else, defer to the next operator review unless the skill
+   explicitly handles it.
+
+Do not invent work to fill the tick. A no-op exit is the correct
+behaviour when the inbox has nothing for you.

--- a/agents/luce/ROLE.md
+++ b/agents/luce/ROLE.md
@@ -1,0 +1,24 @@
+# luce — role
+
+Archetype: `product`. Host: `ocean` (server-resident; runs autonomously
+on the task-loop timer).
+
+## In scope
+
+- Mail triage: inbox sweeps, ping/pong replies, routing operator-facing
+  threads.
+- Calendar: surfacing conflicts, prepping daily/weekly views.
+- Project status: rolling up state from @../PROJECTS.yaml and per-project
+  notes.
+- Routine executive-assistant duties (reservations, birthdays, follow-ups).
+
+## Out of scope — escalate
+
+- Code changes → drago.
+- Architecture or infra decisions → drago + operator.
+- New project commitments → operator.
+
+## Capabilities (from `keystone.os.agents.luce`)
+
+`executive-assistant`. The skill cascade resolves to: ks.system,
+ks.assistant, ks.projects, ks.ea, and the cross-tool skills.

--- a/agents/luce/SOUL.md
+++ b/agents/luce/SOUL.md
@@ -1,0 +1,12 @@
+# luce — identity
+
+You are luce. You are observant, prioritising, and synthesising. You read
+mail, calendar, and project state; you summarise; you escalate the items
+the operator actually needs to see.
+
+You speak in short bullets when reporting. You ask clarifying questions
+only when a decision blocks; otherwise you make the reasonable call and
+note the assumption.
+
+You do not write code yourself for production changes. If implementation
+is required, hand off to drago with a clear scope note.

--- a/agents/skills/task-loop/SKILL.md
+++ b/agents/skills/task-loop/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: task-loop
+description: "Process the agent's inbox once: reply to [ping] messages with [pong], then exit. Designed to be invoked on a recurring systemd timer."
+---
+
+# Task-loop
+
+A single non-interactive pass over the agent's inbox. Invoked by a
+systemd user timer (see keystone `taskLoop` module). Each tick is a
+fresh process — no internal looping, no long-running state.
+
+Initial scope is ping/pong only. Future revisions will add calendar,
+forgejo, and project-status ingest. Do not invent work outside this
+scope; exit cleanly when there is nothing to do.
+
+## Context to load before acting
+
+Read these from the agent's home directory:
+
+- @~/SOUL.md, @~/ROLE.md, @~/AGENTS.md — identity and operating rules.
+- @~/TEAM.md, @~/HUMAN.md — addressing and operator profile.
+- @~/PROJECTS.yaml — portfolio for disambiguating thread context.
+
+## Procedure
+
+1. List unread envelopes as JSON:
+
+   ```sh
+   himalaya envelope list --output json
+   ```
+
+2. Filter the result in-memory to envelopes whose `subject` starts with
+   `[ping] ` and whose `flags` array does NOT include `Answered` (or the
+   server-specific spelling — IMAP exposes the flag as `\Answered`,
+   himalaya's JSON output usually normalises to `Answered`).
+
+3. For each matching envelope:
+   - Fetch the full message body for context:
+     ```sh
+     himalaya message read <id>
+     ```
+   - Reply with body `pong`:
+     ```sh
+     himalaya message reply <id> pong
+     ```
+     `himalaya message reply` prefills the standard `Re: <subject>` and
+     marks the source envelope `\Answered` on send. Verify both before
+     moving on — if either is missing, fall back to:
+     ```sh
+     himalaya flag add <id> answered
+     ```
+
+4. After processing all matches, exit 0. Do not poll, do not retry, do
+   not write to TASKS.yaml — the next tick of the systemd timer will
+   pick up new mail.
+
+## Hard limits
+
+- Do not reply to a message that is not a `[ping] <tag>`.
+- Do not initiate new threads from this skill.
+- Do not invoke other skills (no deepwork, no /ks, no /ks.ea) inside
+  this tick.
+- If the inbox lookup fails (network, auth), log the error to stderr
+  and exit non-zero. The timer will retry on the next tick.

--- a/modules/agent-home-state.nix
+++ b/modules/agent-home-state.nix
@@ -1,0 +1,97 @@
+# Symlink the canonical agent-state tree (this flake's `agents/`) into each
+# local agent's home directory. Mirrors PR #29's pattern of treating the
+# repo as the source of truth and exposing it through `~/...` paths the
+# agent's CLI tools (Claude, Codex, Gemini) read natively.
+#
+# Per-host: only wires agents whose `keystone.os.agents.<name>.host`
+# matches `networking.hostName`. Other agents' state files live on their
+# assigned host.
+#
+# Tracked files (committed): TEAM.md, HUMAN.md, PROJECTS.yaml, and the
+# per-agent SOUL.md / ROLE.md / AGENTS.md.
+#
+# Runtime files (gitignored, touched by activation): TASKS.yaml,
+# SCHEDULES.yaml, ISSUES.yaml. Activation creates the empty target file
+# in the flake checkout if it does not already exist so the symlink has
+# something to point at.
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+with lib;
+let
+  osCfg = config.keystone.os;
+  flakePath = config.keystone.systemFlake.path;
+  hostName = config.networking.hostName;
+
+  # Agents enabled on this host (terminal must be on; otherwise the agent
+  # has no home-manager block to extend).
+  localAgents = filterAttrs (
+    _name: agentCfg: agentCfg.host == hostName && agentCfg.terminal.enable
+  ) osCfg.agents;
+
+  # Shared symlinks — same target file for every agent on this host.
+  sharedFiles = {
+    "TEAM.md" = "${flakePath}/agents/TEAM.md";
+    "HUMAN.md" = "${flakePath}/agents/HUMAN.md";
+    "PROJECTS.yaml" = "${flakePath}/agents/PROJECTS.yaml";
+  };
+
+  # Tracked per-agent files. SOUL/ROLE/AGENTS are in-repo.
+  perAgentTracked = name: {
+    "SOUL.md" = "${flakePath}/agents/${name}/SOUL.md";
+    "ROLE.md" = "${flakePath}/agents/${name}/ROLE.md";
+    "AGENTS.md" = "${flakePath}/agents/${name}/AGENTS.md";
+  };
+
+  # Runtime state files. Gitignored in the flake; activation `touch`es
+  # the target in the checkout if missing so the symlink resolves.
+  runtimeFileNames = [
+    "TASKS.yaml"
+    "SCHEDULES.yaml"
+    "ISSUES.yaml"
+  ];
+
+  runtimeTargets = name: map (fname: "${flakePath}/agents/${name}/${fname}") runtimeFileNames;
+in
+{
+  config = mkIf (osCfg.enable && localAgents != { }) (
+    optionalAttrs (options ? home-manager) {
+      home-manager.users = mapAttrs' (
+        name: _agentCfg:
+        nameValuePair "agent-${name}" (
+          { config, lib, ... }:
+          let
+            mkLink = target: config.lib.file.mkOutOfStoreSymlink target;
+            runtimeLinks = lib.listToAttrs (
+              map (
+                fname: lib.nameValuePair fname { source = mkLink "${flakePath}/agents/${name}/${fname}"; }
+              ) runtimeFileNames
+            );
+            sharedLinks = lib.mapAttrs (_n: t: { source = mkLink t; }) sharedFiles;
+            trackedLinks = lib.mapAttrs (_n: t: { source = mkLink t; }) (perAgentTracked name);
+          in
+          {
+            # CRITICAL: these symlinks point INTO the consumer flake checkout
+            # via mkOutOfStoreSymlink so an `ks update --dev` immediately
+            # reflects edits without a rebuild. The runtime files live behind
+            # the gitignore — activation pre-creates them so the symlinks are
+            # not dangling on first deploy.
+            home.file = sharedLinks // trackedLinks // runtimeLinks;
+
+            home.activation.agentStateTouchRuntime = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
+              for target in ${lib.escapeShellArgs (runtimeTargets name)}; do
+                if [ ! -e "$target" ]; then
+                  mkdir -p "$(dirname "$target")"
+                  : > "$target"
+                fi
+              done
+            '';
+          }
+        )
+      ) localAgents;
+    }
+  );
+}

--- a/modules/keystone/os.nix
+++ b/modules/keystone/os.nix
@@ -19,6 +19,7 @@
     ../keys.nix
     ../../hosts/common/global/openssh.nix
     ../../hosts/common/agent-identities.nix
+    ../agent-home-state.nix
   ];
 
   # Fleet-wide identity


### PR DESCRIPTION
## Summary

Stacked on PR #29 (`.agents/skills/` spec adoption). Adds the consumer-side
scaffolding for the new symlinked agent-state layout described in the
goofy-tide plan: per-agent docs/state files in this repo, the portable
task-loop skill markdown, and home-manager activation that materialises
the symlinks in each agent's home dir.

The keystone-side companion (the `taskLoop` systemd timer module) lands
separately as PR 2A on keystone. This PR does NOT enable the task-loop
on any agent — that's a follow-up PR.

## New file tree

```
agents/
├── TEAM.md            # shared roster
├── HUMAN.md           # operator profile
├── PROJECTS.yaml      # shared portfolio (stub schema)
├── drago/
│   ├── SOUL.md        # identity / voice
│   ├── ROLE.md        # scope / responsibilities
│   └── AGENTS.md      # @-mention header preserved; existing audit policy retained
├── luce/
│   ├── SOUL.md
│   ├── ROLE.md
│   └── AGENTS.md
└── skills/task-loop/SKILL.md   # cross-tool ping/pong loop, no deepwork
```

Plus `modules/agent-home-state.nix` (imported via `modules/keystone/os.nix`)
which symlinks the tree into each `agent-<name>` home directory using
`mkOutOfStoreSymlink`. Activation `touch`es the gitignored runtime files
(`TASKS.yaml`, `SCHEDULES.yaml`, `ISSUES.yaml`) before the link check so
the symlinks resolve on first deploy.

## Symlinks materialised per local agent

```
~/TEAM.md          → <flake>/agents/TEAM.md
~/HUMAN.md         → <flake>/agents/HUMAN.md
~/PROJECTS.yaml    → <flake>/agents/PROJECTS.yaml
~/SOUL.md          → <flake>/agents/<name>/SOUL.md
~/ROLE.md          → <flake>/agents/<name>/ROLE.md
~/AGENTS.md        → <flake>/agents/<name>/AGENTS.md
~/TASKS.yaml       → <flake>/agents/<name>/TASKS.yaml      # gitignored
~/SCHEDULES.yaml   → <flake>/agents/<name>/SCHEDULES.yaml  # gitignored
~/ISSUES.yaml      → <flake>/agents/<name>/ISSUES.yaml     # gitignored
```

Per-host: only agents whose `keystone.os.agents.<name>.host` matches
`networking.hostName` are wired. Other agents' state files live on their
assigned host.

## Validation

- `nix flake check --no-warn-dirty` passes for all 6 NixOS configurations
  (`maia`, `ncrmro-laptop`, `mercury`, `ocean`, `ncrmro-workstation`,
  `catalystPrimary`). The only error surfaced by `nix flake check` is a
  pre-existing `packages.x86_64-linux.vm-image-mercury` disko issue
  unrelated to this PR — confirmed present on master.
- `nix build .#nixosConfigurations.ocean.config.system.build.toplevel`
  succeeds; ocean evaluates with `home-manager-agent-luce.service` wired.
- `nix build .#nixosConfigurations.ncrmro-workstation.config.system.build.toplevel`
  dry-run succeeds; workstation evaluates with the agent-drago home block.

## Test plan

- [ ] After merge to `master` and an `ks update ocean`, `ls -la /home/agent-luce/` shows the expected symlinks resolving into the flake checkout.
- [ ] `readlink /home/agent-luce/TASKS.yaml` resolves; the target exists (touched by activation).
- [ ] PR 3 (separate) flips `taskLoop.enable = true` and authors concrete SOUL/ROLE content; live ping/pong exchange follows.

## Notes for reviewers

- All authored SOUL/ROLE/AGENTS/TEAM/HUMAN/PROJECTS content is stub-quality
  per the plan — the operator will refine in PR 3 or later.
- `agents/drago/AGENTS.md` had pre-existing operator-authored content; this
  PR only prepends an `@`-mention header and otherwise leaves it intact.
- The home-manager wiring uses `optionalAttrs (options ? home-manager)` so
  the module is safe on hosts that don't enable home-manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)