### PR TITLE
feat(agents): enable cross-tool task-loop for luce + drago

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1288,11 +1288,11 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1779308613,
-        "narHash": "sha256-YPD0Zdfr/1je21FCbb5izcpwlihqrgGC0Tp5h3M+TX0=",
+        "lastModified": 1779316440,
+        "narHash": "sha256-rnTp5ctojM8NrJl5buWvPPc5BHqLhIQllP0WBNzdQS8=",
         "owner": "ncrmro",
         "repo": "keystone",
-        "rev": "2b7282b39f2739ecddc1dfb9190f26adc06d4b72",
+        "rev": "e8a64b120337ab11ab025b298d3879be874595d0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1288,15 +1288,16 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1779295064,
-        "narHash": "sha256-go0MYGBTC6N2JXO0bDISIvNwn7QoLsqfWyj255dLmlo=",
+        "lastModified": 1779308613,
+        "narHash": "sha256-YPD0Zdfr/1je21FCbb5izcpwlihqrgGC0Tp5h3M+TX0=",
         "owner": "ncrmro",
         "repo": "keystone",
-        "rev": "edfb84ae9060dc4a3cda31a7f62663d6fd6c2ad4",
+        "rev": "2b7282b39f2739ecddc1dfb9190f26adc06d4b72",
         "type": "github"
       },
       "original": {
         "owner": "ncrmro",
+        "ref": "feat/agents-task-loop-module",
         "repo": "keystone",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,12 @@
     # Keystone - self-sovereign infrastructure platform
     # NEVER CHANGE THIS URL TO A LOCAL PATH. EVER. USE THE GITHUB REPO.
     # For local dev without commits, use: ./bin/dev-keystone <hostname>
+    #
+    # Temporarily pinned to feat/agents-task-loop-module (which is stacked
+    # on refactor/agents-rip-out-notes). Re-lock to a main merge commit once
+    # those keystone PRs land.
     keystone = {
-      url = "github:ncrmro/keystone";
+      url = "github:ncrmro/keystone/feat/agents-task-loop-module";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -83,7 +87,6 @@
           "engineer"
           "product"
           "project-manager"
-          "notes"
         ];
       };
 

--- a/home-manager/ncrmro/base.nix
+++ b/home-manager/ncrmro/base.nix
@@ -92,7 +92,6 @@
 
   keystone.notes = {
     enable = true;
-    repo = "ssh://forgejo@git.ncrmro.com:2222/ncrmro/notes.git";
     zk.enable = true;
   };
 

--- a/hosts/common/agent-identities.nix
+++ b/hosts/common/agent-identities.nix
@@ -22,10 +22,13 @@
       archetype = "engineer";
       capabilities = [
         "engineer"
-        "notes"
       ];
       mail.provision = true; # provision Stalwart account on server host (ocean)
       git.provision = true; # provision Forgejo account on server host (ocean)
+      taskLoop = {
+        enable = true;
+        tool = "claude";
+      };
     };
     luce = {
       host = "ocean";
@@ -33,11 +36,14 @@
       email = "luce@ncrmro.com";
       archetype = "product";
       capabilities = [
-        "notes"
         "executive-assistant"
       ];
       mail.provision = true;
       git.provision = true;
+      taskLoop = {
+        enable = true;
+        tool = "claude";
+      };
     };
   };
 }

--- a/modules/agent-home-state.nix
+++ b/modules/agent-home-state.nix
@@ -39,6 +39,19 @@ let
     "PROJECTS.yaml" = "${flakePath}/agents/PROJECTS.yaml";
   };
 
+  # Skill-tree + per-tool top-level docs. All three CLI tools (Claude,
+  # Codex, Gemini) read these natively; the canonical skill content lives
+  # in `agents/skills/` and the operating rules in `agents/_shared/AGENTS.md`.
+  # nixos-config#29 wires these for ncrmro via the keystone aiExtensions
+  # surface; agent users need the same wiring through this module.
+  skillTreeFiles = {
+    ".agents/skills" = "${flakePath}/agents/skills";
+    ".claude/skills" = "${flakePath}/agents/skills";
+    ".claude/CLAUDE.md" = "${flakePath}/agents/_shared/AGENTS.md";
+    ".gemini/GEMINI.md" = "${flakePath}/agents/_shared/AGENTS.md";
+    ".codex/AGENTS.md" = "${flakePath}/agents/_shared/AGENTS.md";
+  };
+
   # Tracked per-agent files. SOUL/ROLE/AGENTS are in-repo.
   perAgentTracked = name: {
     "SOUL.md" = "${flakePath}/agents/${name}/SOUL.md";
@@ -72,6 +85,7 @@ in
             );
             sharedLinks = lib.mapAttrs (_n: t: { source = mkLink t; }) sharedFiles;
             trackedLinks = lib.mapAttrs (_n: t: { source = mkLink t; }) (perAgentTracked name);
+            skillTreeLinks = lib.mapAttrs (_n: t: { source = mkLink t; }) skillTreeFiles;
           in
           {
             # CRITICAL: these symlinks point INTO the consumer flake checkout
@@ -79,7 +93,7 @@ in
             # reflects edits without a rebuild. The runtime files live behind
             # the gitignore — activation pre-creates them so the symlinks are
             # not dangling on first deploy.
-            home.file = sharedLinks // trackedLinks // runtimeLinks;
+            home.file = sharedLinks // trackedLinks // runtimeLinks // skillTreeLinks;
 
             home.activation.agentStateTouchRuntime = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
               for target in ${lib.escapeShellArgs (runtimeTargets name)}; do


### PR DESCRIPTION
## Summary

Wires the new `taskLoop` for drago + luce on top of keystone's new minimal task-loop module. After this PR + the keystone PRs merge and ocean/workstation deploy, both agents stop running the old autopilot (those timers were ripped out in keystone#546) and start the new task-loop, whose first job is `[ping]`/`[pong]` mail.

### Changes

- `flake.nix`: temporarily pin keystone input to branch ref `feat/agents-task-loop-module` (stacked on `refactor/agents-rip-out-notes`). Drop `"notes"` from the ncrmro adminUser capabilities — the enum value is gone in keystone#546.
- `hosts/common/agent-identities.nix`: drop `"notes"` from drago + luce capabilities; add `taskLoop = { enable = true; tool = "claude"; }` to both.
- `modules/agent-home-state.nix`: extend the per-agent symlink wiring (introduced in #31) with the cross-tool skill-tree links:
  - `~/.agents/skills` -> `<flake>/agents/skills`
  - `~/.claude/skills` -> `<flake>/agents/skills`
  - `~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, `~/.codex/AGENTS.md` -> `<flake>/agents/_shared/AGENTS.md`
- `home-manager/ncrmro/base.nix`: drop `keystone.notes.repo` — option removed by keystone#546.

### Stacking + blocking

- **Stacked on**: #31 (which is stacked on #29).
- **Blocked on**: keystone #546 (`refactor/agents-rip-out-notes`) + keystone #547 (`feat/agents-task-loop-module`) merging. Follow-up: re-lock the keystone flake input from the branch ref to the main merge commit.

### Known keystone bug surfaced during verification

`nix build .#nixosConfigurations.ocean.config.system.build.toplevel` fails on the current keystone branch with:

```
error: The option `systemd.user.services.agent-luce-task-loop.environment.PATH' has conflicting definition values:
 - In nixos/modules/system/boot/systemd/user.nix: <coreutils/findutils/.../systemd>
 - In modules/os/agents/task-loop.nix: /etc/profiles/per-user/agent-luce/bin:/run/current-system/sw/bin
```

Same failure on `ncrmro-workstation` for `agent-drago-task-loop`. Fix lives in keystone's `modules/os/agents/task-loop.nix`: wrap the `PATH = ...` value with `lib.mkForce` (or drop the override and prepend to the systemd default). Per the PR-3 plan I have not touched keystone here — leaving for the operator to iterate on keystone#547.

### Build / check status

| host | result |
| --- | --- |
| maia | OK |
| ncrmro-laptop | OK |
| mercury | OK |
| catalystPrimary | OK |
| ocean | fails on keystone PATH conflict (see above) |
| ncrmro-workstation | fails on keystone PATH conflict (see above) |

## Test plan

- [ ] keystone#546 + keystone#547 merge
- [ ] Fix the `PATH` conflict in keystone's `task-loop.nix` (`lib.mkForce`)
- [ ] Re-lock keystone flake input here to the main merge commit
- [ ] `nix flake check` + ocean/workstation toplevel builds both clean
- [ ] Deploy ocean (`ks update ocean`) and workstation (`ks update ncrmro-workstation`)
- [ ] Live: drago sends mail with subject `[ping] e2e-test-<date>` to `luce@ncrmro.com` body `ping`; luce's task-loop replies with `Re: [pong] e2e-test-<date>` within `taskLoop.interval` (15min default)
- [ ] Confirm `systemctl --user --machine=agent-luce@ list-timers --all` shows exactly `agent-luce-task-loop` (no notes-sync / scheduler / old task-loop timers)
- [ ] `readlink /home/agent-luce/.claude/skills`, `/home/agent-luce/.agents/skills`, etc. resolve into this flake's checkout