### PR TITLE
feat(hosts): enable keystone.os.githubTokenNix on desktops

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1288,11 +1288,11 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1778871364,
-        "narHash": "sha256-Urf2/zPQzKBtfWCJiOYY4Y5pA7RREXHjBTYQr2Hy+wQ=",
+        "lastModified": 1779343893,
+        "narHash": "sha256-UPsSPW0JJcAPkThmEy+U20/cA76pFPsKBTu2TtNhmZg=",
         "owner": "ncrmro",
         "repo": "keystone",
-        "rev": "6348d206db6d6d6d56743b4407e69c85d4f6c9b5",
+        "rev": "31b96326ef94a5a1282d82fd01ebcbd30854c01d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
     "agenix-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1775161185,
-        "narHash": "sha256-Mgthcagr5CJ3RPJHM9Ar8D2qEBlUlNYjy4t9JlqenaY=",
+        "lastModified": 1779343663,
+        "narHash": "sha256-PBGnBZnR8kNDfSa66+1ZWLRcY7Rfn/QR/Qwtl0O+fGI=",
         "ref": "refs/heads/main",
-        "rev": "84e80f1c9b02d00f8fdea954fd12b5a516b71580",
-        "revCount": 39,
+        "rev": "20f990165e9b1bec693b11d5c3c610a69fe990f3",
+        "revCount": 42,
         "type": "git",
         "url": "ssh://forgejo@git.ncrmro.com:2222/ncrmro/agenix-secrets.git"
       },

--- a/home-manager/ncrmro/base.nix
+++ b/home-manager/ncrmro/base.nix
@@ -96,7 +96,7 @@
     zk.enable = true;
   };
 
-  keystone.terminal.aiExtensions.experimental = true;
+  keystone.terminal.aiExtensions.enable = true;
   keystone.terminal.calendar.enable = true;
   keystone.terminal.contacts.enable = true;
   keystone.terminal.timer.enable = true;

--- a/hosts/ncrmro-laptop/default.nix
+++ b/hosts/ncrmro-laptop/default.nix
@@ -62,13 +62,20 @@
     file = "${inputs.agenix-secrets}/secrets/attic-push-token.age";
   };
 
-  # GitHub agents token
-  # GitHub agents token
+  # GitHub agents token (user-readable; for keystone.terminal.github future opt-in)
   age.secrets.github-agents-token = {
     file = "${inputs.agenix-secrets}/secrets/github-agents-token.age";
     owner = "ncrmro";
     mode = "0400";
   };
+
+  # GitHub token for the nix daemon (root-readable, for /etc/nix/access-tokens.conf)
+  age.secrets.nix-flake-github-token = {
+    file = "${inputs.agenix-secrets}/secrets/nix-flake-github-token.age";
+    owner = "root";
+    mode = "0400";
+  };
+  keystone.os.githubTokenNix.enable = true;
 
   # Grafana API token for MCP and dashboards
   age.secrets.grafana-api-token = {

--- a/hosts/workstation/default.nix
+++ b/hosts/workstation/default.nix
@@ -107,13 +107,20 @@
     mode = "0400";
   };
 
-  # GitHub agents token
-  # GitHub agents token
+  # GitHub agents token (user-readable; for keystone.terminal.github future opt-in)
   age.secrets.github-agents-token = {
     file = "${inputs.agenix-secrets}/secrets/github-agents-token.age";
     owner = "ncrmro";
     mode = "0400";
   };
+
+  # GitHub token for the nix daemon (root-readable, for /etc/nix/access-tokens.conf)
+  age.secrets.nix-flake-github-token = {
+    file = "${inputs.agenix-secrets}/secrets/nix-flake-github-token.age";
+    owner = "root";
+    mode = "0400";
+  };
+  keystone.os.githubTokenNix.enable = true;
 
   # Grafana API token for MCP and dashboards
   age.secrets.grafana-api-token = {

--- a/secrets.nix
+++ b/secrets.nix
@@ -73,6 +73,10 @@ in
   # Cliflux config (Miniflux CLI client config with API key, for desktops)
   "secrets/cliflux-config.age".publicKeys = adminKeys ++ desktops;
 
-  # GitHub agents token
+  # GitHub agents token (user-readable; consumed by keystone.terminal.github)
   "secrets/github-agents-token.age".publicKeys = adminKeys ++ desktops;
+
+  # GitHub token for the nix daemon — root-readable, system-key recipients.
+  # Consumed by keystone.os.githubTokenNix; see conventions/tool.nix.md.
+  "secrets/nix-flake-github-token.age".publicKeys = adminKeys ++ desktops;
 }


### PR DESCRIPTION
## Summary

- Adds `age.secrets.nix-flake-github-token` declaration on ncrmro-workstation and ncrmro-laptop with `owner = "root"; mode = "0400";`.
- Adds the secret entry to `secrets.nix` with `adminKeys ++ desktops` recipients.
- Enables `keystone.os.githubTokenNix` on both hosts — the new keystone module that wires the token into `/etc/nix/access-tokens.conf` for authenticated GitHub flake fetches.

Fixes intermittent 60/hr anonymous rate-limit failures on \`ks update\` / \`nix flake update keystone\`.

## Design notes

- The existing `age.secrets.github-agents-token` blocks are **left in place** — they will be consumed by `keystone.terminal.github` once that module (on the keystone `feat/terminal-github-pats` branch) lands and is enabled in the user home-manager profile. This is the user-readable agents PAT; the new `nix-flake-github-token` is the root-readable nix-daemon counterpart. Two distinct secrets per the convention.

## Test plan

- [ ] `ks build` succeeds on ncrmro-workstation and ncrmro-laptop **after**:
  - The keystone PR merges (defining `keystone.os.githubTokenNix`).
  - The agenix-secrets PR merges (adding recipients).
  - The `.age` file is encrypted (manual step: \`agenix -e secrets/nix-flake-github-token.age\` in agenix-secrets).
- [ ] After \`ks update --dev\`, \`systemctl status nix-github-access-token.service\` is \`active (exited)\`.
- [ ] \`sudo cat /etc/nix/access-tokens.conf\` shows \`access-tokens = github.com=<token>\` mode 0640.
- [ ] \`nix flake update keystone\` no longer warns about anonymous rate-limit headers.

## Dependencies

- Requires: ncrmro/keystone PR (defines the module)
- Requires: ncrmro/agenix-secrets PR (adds the secret with system-key recipients)
- Requires: encrypting the new \`nix-flake-github-token.age\` in agenix-secrets before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)