### PR TITLE
chore(deepwork): align project job with vega milestone/spec convention

### DIFF
--- a/deepwork/jobs/project/job.yml
+++ b/deepwork/jobs/project/job.yml
@@ -2166,14 +2166,26 @@ workflows:
              - `yellow`: some stories have unresolved questions — spikes required before specs can be written
              - `red`: one or more stories are infeasible or require scope renegotiation before proceeding
 
-          6. **Post the internal FAQ as a comment**
-             - Post the internal FAQ as a comment on the milestone issue (visible to all stakeholders)
+          6. **Publish the internal FAQ to the milestone directory**
+
+             Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md`), the canonical in-repo home for a milestone's internal FAQ is `docs/milestones/M<N>-<ms-slug>/internal-faq.md` on the `milestone/<ms-slug>` branch.
+
+             - Derive `<ms-slug>` and the Forgejo milestone id `<N>` from the milestone issue's milestone metadata (or the prior `setup_milestone` artifacts)
+             - Check out `milestone/<ms-slug>` (or work in its worktree)
+             - Write the full internal FAQ to `docs/milestones/M<N>-<ms-slug>/internal-faq.md`, replacing the stub created by `setup_milestone`
+             - Commit: `git commit -m "docs(milestone): publish internal FAQ for <ms-slug>"`
+             - Push: `git push origin milestone/<ms-slug>`
+
+          7. **Post the internal FAQ as a comment**
+             - Post the internal FAQ as a comment on the milestone issue (visible to all stakeholders); the comment body MAY link back to the canonical `docs/milestones/M<N>-<ms-slug>/internal-faq.md` written in step 6
              - GitHub: `gh issue comment {number} --repo {owner}/{repo} --body "$BODY"`
              - Forgejo: `fj issue comment {number} -r {owner}/{repo} --body "$BODY"`
 
           ## Output Format
 
-          ### internal_faq.md
+          ### docs/milestones/M<N>-<ms-slug>/internal-faq.md
+
+          The canonical in-repo home for the internal FAQ. Written to the `milestone/<ms-slug>` branch by step 6. The DeepWork artifact tracked as `internal_faq` is this file (or a copy of its content under `.deepwork/tmp/` for handoff purposes).
 
           ```markdown
           # Internal FAQ: [Milestone Title]
@@ -2218,6 +2230,7 @@ workflows:
           - T-shirt sizing is concrete (not "TBD") with a written justification for each story
           - Required spikes are listed with a clear blocking question (not just "needs investigation")
           - Summary verdict is one of `green`, `yellow`, or `red` with supporting rationale
+          - The internal FAQ is committed to `docs/milestones/M<N>-<ms-slug>/internal-faq.md` on the `milestone/<ms-slug>` branch and pushed before the step completes
           - Internal FAQ is posted as a comment on the milestone issue before the step completes
 
           ## Context

--- a/deepwork/jobs/project/job.yml
+++ b/deepwork/jobs/project/job.yml
@@ -2515,29 +2515,37 @@ workflows:
 
       - name: create_plan_issue
         instructions: |
-          # Create Implementation Plan Issue
+          # Create Spec Tracking Issue
 
           ## Objective
 
-          Create a **single** plan issue on the milestone that serves as the sole tracking issue for all implementation work. This issue includes happy paths, test expectations, design mockups, demo artifacts, **and a phased task checklist documenting parallelism and blocking dependencies**. PRs are opened directly against this issue — no child issues are created.
+          Create a **single** `Spec: <spec-slug>` tracking issue that serves as the sole tracking issue for all implementation work on this spec. This issue includes happy paths, test expectations, design mockups, demo artifacts, a "Used by milestones" reverse-lookup section, **and a phased task checklist documenting parallelism and blocking dependencies**. PRs are opened directly against this issue — no child issues are created. After the issue succeeds, append `<spec-slug>` to the parent milestone's `milestone.yaml` `dependsOnSpecs` (if a parent milestone was identified).
 
           ## Task
 
-          Read the scope analysis, review decision, and specs PR report from prior steps, then compose and create one comprehensive plan issue on the project's platform. This issue becomes the single reference point for all implementation work on the milestone. Multiple PRs will reference this issue via `Part of #N` or `Closes #N`.
+          Read the scope analysis, review decision, and specs PR report from prior steps, then compose and create one comprehensive `Spec:` issue on the project's platform. This issue becomes the single reference point for all implementation work tied to the spec. Multiple PRs will reference this issue via `Part of #N` or `Closes #N`.
 
           **IMPORTANT: Do NOT create child issues.** All work is tracked in this issue's task checklist.
 
-          **ISSUE COUNT CAP**: Create exactly ONE plan issue. If you identify a genuinely distinct feature that warrants its own issue (large delineating feature, not just a subtask), you MUST stop and ask the human for approval before creating it. The absolute maximum is 1-3 additional issues, and each requires explicit human sign-off. Issue bloat (10+ issues per milestone) has been a recurring problem — err on fewer issues.
+          **ISSUE COUNT CAP**: Create exactly ONE `Spec:` issue per spec. If you identify a genuinely distinct feature that warrants its own issue (large delineating feature, not just a subtask), you MUST stop and ask the human for approval before creating it. The absolute maximum is 1-3 additional issues, and each requires explicit human sign-off. Issue bloat (10+ issues per milestone) has been a recurring problem — err on fewer issues.
+
+          ### Convention reference — Spec issue title and labels
+
+          Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md` in the project repo when present):
+
+          - Title: `Spec: <spec-slug>` (e.g., `Spec: eval-cli-runner`). Do NOT use `Plan: <milestone title>` or `(M#)` suffixes.
+          - Label: `kind:spec`
+          - Body must include a **"Used by milestones"** section listing every milestone whose `milestone.yaml` `dependsOnSpecs` includes this spec, or `(none yet)` if no parent.
 
           ### Process
 
           1. **Read prior step outputs**
              - Load `scope_analysis.md` — for the story-to-system map and prerequisites
              - Load `review_decision.md` — for the approved MVP scope (in scope + renegotiated stories only)
-             - Load `specs_pr_report.md` — for the specs PR number/URL and spec file details
-             - Extract the milestone title, issue number, and platform
+             - Load `specs_pr_report.md` — for the spec slug, spec directory path, specs PR number/URL, parent milestone slug (if any), and spec file details
+             - Extract the platform and repo
 
-          2. **Compose the plan issue body**
+          2. **Compose the spec issue body**
              For each **approved** user story from the review decision, include:
              - **Happy path requirements** — the expected user flow when everything works correctly
              - **Red/green test expectations** — what test should fail before implementation (red) and pass after (green). Be specific about the assertion, not just "it should work."
@@ -2547,9 +2555,32 @@ workflows:
              Also include:
              - **Implementation order** — which stories can be parallelized and which have dependencies
              - **Feature flag requirements** — which stories need feature flags for safe deployment
-             - References to the specs PR, the review decision, and the original milestone issue
+             - References to the specs PR, the review decision, and the parent milestone issue (if any)
+             - A **"Used by milestones"** section (see step 3)
 
-          3. **Compose the phased task checklist**
+          3. **Compose the "Used by milestones" section**
+
+             Scan every `docs/milestones/*/milestone.yaml` in the repo for entries whose `dependsOnSpecs` already contains `<spec-slug>`:
+
+             ```bash
+             # In the project repo, on main:
+             for f in docs/milestones/*/milestone.yaml; do
+               yq -r 'select(.dependsOnSpecs[]? == "<spec-slug>") | .slug + " (" + .forgejoIssue + ")"' "$f"
+             done
+             ```
+
+             Render the result inside the issue body:
+
+             ```markdown
+             ## Used by milestones
+
+             - eval-harness (#10)
+             - cli-onboarding (#23)
+             ```
+
+             If no milestones currently depend on this spec, render `(none yet)`. The later sub-step (step 6) will add the parent milestone declared at workflow start, so the reverse-lookup will be live as soon as that yaml is committed.
+
+          4. **Compose the phased task checklist**
 
              Break the work into tasks grouped by phase. Each task should map to a single small PR (2-3 files max). Use conventional commit prefixes for task names. Document parallelism and blocking:
 
@@ -2570,7 +2601,7 @@ workflows:
 
              - [ ] test: add recipe API integration tests
 
-             ### Future Work (out of milestone scope)
+             ### Future Work (out of spec scope)
 
              - Recipe ratings and reviews
              - Recipe import from external sites
@@ -2582,65 +2613,85 @@ workflows:
              - Feature tasks should depend on infrastructure, not on each other
              - Use feature flags to avoid blocking on deployment order
 
-          4. **Create the plan issue**
+          5. **Create the spec issue**
 
              **GitHub**:
 
              ```bash
              gh issue create --repo {owner}/{repo} \
-               --title "Plan: {milestone title}" \
+               --title "Spec: <spec-slug>" \
                --body "$BODY" \
-               --label "engineering" --label "plan" \
-               --milestone "{milestone title}" \
+               --label "kind:spec" --label "engineering" \
                --assignee {drago_username}
              ```
 
              **Forgejo**:
 
              ```bash
-             fj issue create "Plan: {milestone title}" \
+             fj issue create "Spec: <spec-slug>" \
                --body "$BODY" \
-               --label "engineering" --label "plan" \
+               --label "kind:spec" --label "engineering" \
                -r {owner}/{repo}
              ```
 
-             Then link to milestone and assign via API.
-             - Ensure `engineering` and `plan` labels exist (create if missing)
+             Then assign via API.
+             - Ensure `kind:spec` and `engineering` labels exist (create if missing)
              - Assign to Drago (CTO) — read username from `.agents/TEAM.md`
-             - Link to the milestone
+             - The `Spec:` issue is NOT linked to a Forgejo milestone — the milestone-spec relationship lives in `milestone.yaml.dependsOnSpecs` (the next step), and the parent milestone issue cross-references the spec issue in its own body.
 
-          5. **Write the plan issue report**
+          6. **Update the parent milestone's `milestone.yaml`** (if a parent milestone was named at workflow start)
+
+             On the `milestone/<ms-slug>` branch (or in its worktree), append `<spec-slug>` to `dependsOnSpecs` in `docs/milestones/M<N>-<ms-slug>/milestone.yaml`. Skip this step entirely if the spec is orphan (no parent milestone).
+
+             ```bash
+             # In the milestone worktree:
+             yq -i ".dependsOnSpecs += [\"<spec-slug>\"] | .dependsOnSpecs |= unique" \
+               docs/milestones/M<N>-<ms-slug>/milestone.yaml
+             git add docs/milestones/M<N>-<ms-slug>/milestone.yaml
+             git commit -m "docs(milestone): depend on spec <spec-slug>"
+             git push origin milestone/<ms-slug>
+             ```
+
+             Use `unique` to avoid duplicate entries on re-runs.
+
+          7. **Write the plan issue report**
+             - Record whether the parent milestone yaml was updated (and the resulting `dependsOnSpecs` list), or "no parent milestone — orphan spec"
 
           ## Output Format
 
           ### plan_issue_report.md
 
-          A report documenting the created plan issue.
+          A report documenting the created spec issue.
 
           **Structure**:
 
           ```markdown
-          # Plan Issue Report: [Milestone Title]
+          # Spec Issue Report: [Spec Slug]
 
           ## Platform
 
           - **Platform**: [github | forgejo]
           - **Repository**: [owner/repo]
 
-          ## Plan Issue
+          ## Spec Issue
 
           - **Number**: #[number]
-          - **Title**: Plan: [milestone title]
+          - **Title**: Spec: [spec-slug]
           - **URL**: [issue URL]
-          - **Milestone**: [milestone title]
           - **Assignee**: [Drago's username]
-          - **Labels**: engineering, plan
+          - **Labels**: kind:spec, engineering
 
           ## References
 
-          - **Milestone Issue**: #[milestone_issue_number]
+          - **Parent Milestone Issue**: #[milestone_issue_number] (or "(orphan spec)")
           - **Specs PR**: #[specs_pr_number] ([URL])
           - **Review Decision**: [link or summary]
+
+          ## Used by milestones (committed to milestone.yaml)
+
+          - [ms-slug] (#[issue]) — appended by this step
+          - [other-ms-slug] (#[issue]) — pre-existing
+          (or: "(none yet) — orphan spec")
 
           ## Stories Included
 
@@ -2664,28 +2715,31 @@ workflows:
 
           ## Quality Criteria
 
-          - **No child issues created** — all work tracked in this single plan issue's task checklist
-          - Every approved user story from the review decision appears in the plan with happy path requirements
+          - The issue title is `Spec: <spec-slug>` (NOT `Plan: <milestone title>`; NO `(M#)` suffix)
+          - The `kind:spec` and `engineering` labels are applied
+          - **No child issues created** — all work tracked in this single spec issue's task checklist
+          - A "Used by milestones" section is present (with either parent milestone entries or `(none yet)`)
+          - If a parent milestone was named at workflow start, that milestone's `milestone.yaml` was updated to append `<spec-slug>` to `dependsOnSpecs` and committed/pushed on `milestone/<ms-slug>`
+          - Every approved user story from the review decision appears in the issue with happy path requirements
           - A phased task checklist documents all work items with conventional commit prefixes
           - Parallelism and blocking dependencies are clearly documented per phase
           - Each story includes red/green test expectations describing what fails before and passes after implementation
           - ASCII art mockups are included for new UI components or layouts
           - Expected demo artifacts are described for each story (screenshots, videos, preview URLs)
-          - The specs PR is referenced in the plan issue body
-          - The plan issue is linked to the milestone
+          - The specs PR and the spec directory path are referenced in the issue body
 
           ## After this step
 
-          Once the plan issue is created, suggest the following to the user:
+          Once the spec issue is created, suggest the following to the user:
 
-          > The plan issue is ready. Next steps:
+          > The `Spec: <spec-slug>` issue is ready. Next steps:
           >
-          > 1. **`engineer/implement`** — use this workflow for each task in the plan checklist to drive implementation through to merged PRs.
+          > 1. **`engineer/implement`** — use this workflow for each task in the spec issue's task checklist to drive implementation through to merged PRs. Per-task PRs target `spec/<spec-slug>`; `spec/<spec-slug>` merges to `main` when engineering is complete.
           > 2. **`ks.notes` / `notes/process_inbox`** — capture the scope analysis, design decisions, and review outcome into personal notes before implementation begins. Key decisions made during the document review are worth preserving in the Zettelkasten.
 
           ## Context
 
-          This step creates the engineering blueprint for the milestone. The plan issue serves as the **single tracking issue** for all implementation work — no child issues are created. Instead, the plan issue contains a phased task checklist where each task maps to one PR. This avoids issue sprawl (10+ granular issues per milestone) and keeps all context, parallelism notes, and blocking info in one place. PRs reference the plan issue with `Part of #N`. The test expectations follow TDD principles — defining what should fail and pass before writing code. The demo artifacts ensure that every story has a verifiable outcome visible to stakeholders.
+          This step creates the engineering tracking issue for the spec. The `Spec:` issue serves as the **single tracking issue** for all implementation work tied to this engineering scope — no child issues are created. Instead, it contains a phased task checklist where each task maps to one PR. This avoids issue sprawl (10+ granular issues per milestone) and keeps all context, parallelism notes, and blocking info in one place. PRs reference the spec issue with `Part of #N`. The test expectations follow TDD principles — defining what should fail and pass before writing code. The demo artifacts ensure that every story has a verifiable outcome visible to stakeholders. The "Used by milestones" section and the `milestone.yaml.dependsOnSpecs` update are the two halves of the milestone-spec link: one for humans reading the issue, one for tooling reading the yaml.
         inputs:
           scope_analysis: { required: true }
           review_decision: { required: true }

--- a/deepwork/jobs/project/job.yml
+++ b/deepwork/jobs/project/job.yml
@@ -1743,11 +1743,21 @@ workflows:
 
           ## Objective
 
-          Check if a milestone already exists for this scope, create one if needed, update the issue body with refined user stories, and link the issue to the milestone.
+          Check if a milestone already exists for this scope, create one if needed, scaffold the in-repo milestone directory (`docs/milestones/M<N>-<ms-slug>/`) and long-lived `milestone/<ms-slug>` branch, update the issue body with refined user stories, and link the issue to the milestone.
 
           ## Task
 
-          Using the refined stories and milestone title from the previous step, set up the milestone and issue on the project's platform (GitHub or Forgejo).
+          Using the refined stories and milestone title from the previous step, set up the milestone and issue on the project's platform (GitHub or Forgejo) and scaffold the per-milestone docs/branch artifacts per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md` in the project repo when present).
+
+          ### Branch types — convention reference
+
+          Per the milestone/spec convention, the repo has three long-lived branch types, all peers off `main`:
+
+          - `milestone/<ms-slug>` — product integration branch carrying `docs/milestones/M<N>-<ms-slug>/`
+          - `spec/<spec-slug>` — engineering integration branch carrying `docs/specs/NNN-<spec-slug>/`
+          - `spike/<spike-slug>` — short-lived investigation branch whose findings flow into a spec's `research.md` (or as a note on a parent `Spec:` issue) and is then typically discarded
+
+          This step creates the milestone branch. Spec branches are created in `create_specs`. Spikes are created ad hoc by the engineer (e.g., via `engineer/implement` or manually) when an investigation is needed; this workflow does not create them automatically.
 
           ### Process
 
@@ -1758,41 +1768,70 @@ workflows:
           2. **Check for existing milestone**
              - GitHub: `gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.title == "TITLE") | .number'`
              - Forgejo: `tea api /repos/{owner}/{repo}/milestones` or equivalent curl
+             - The milestone title MUST be `Milestone: <ms-slug>` (e.g., `Milestone: eval-harness`). Do NOT use the `(M#) — consolidated user stories` suffix — the `kind:milestone` label and unique slug carry kind and identity.
              - If a matching milestone exists, use it (record its number and URL)
              - If no match, create a new milestone
 
           3. **Create milestone (if needed)**
-             - GitHub: `gh api repos/{owner}/{repo}/milestones -f title="TITLE" -f description="DESCRIPTION"`
+             - GitHub: `gh api repos/{owner}/{repo}/milestones -f title="Milestone: <ms-slug>" -f description="DESCRIPTION"`
              - Forgejo: `tea api -X POST /repos/{owner}/{repo}/milestones` with title and description
              - The milestone description MUST be a short summary (2-3 sentences max). GitHub/Forgejo milestone descriptions are collapsed by default — long content is hidden behind a click.
              - The description MUST include both **why** (the problem or motivation) and **what** (the deliverable). Lead with the why — it gives reviewers instant context on the business reason for the milestone.
              - Example: "Developers lose minutes every day switching between projects across scattered terminals and workspaces. This milestone delivers a unified context system for launching, naming, and switching between scoped work environments. User stories: #174"
+             - Record the Forgejo/GitHub milestone id `<N>` — it becomes the `M<N>` prefix in `docs/milestones/M<N>-<ms-slug>/`.
 
           4. **Ensure required labels exist**
-             - Check that `product` and `engineering` labels exist on the repo
+             - Check that `kind:milestone`, `kind:spec`, `kind:spike`, `product`, and `engineering` labels exist on the repo
              - Create any missing labels:
-               - GitHub: `gh label create "product" --repo owner/repo --description "Product story" --color "0E8A16"`
+               - GitHub: `gh label create "kind:milestone" --repo owner/repo --description "Milestone tracking issue" --color "5319E7"`
                - Forgejo: equivalent API call
              - Use sensible default colors if creating
 
-          5. **Update or create the issue**
+          5. **Create the long-lived milestone branch**
+             - Derive `<ms-slug>` (kebab-case) from the milestone title (e.g., "Eval Harness" -> `eval-harness`)
+             - Ensure local main is current: `git fetch origin && git checkout main && git pull --ff-only`
+             - Create branch `milestone/<ms-slug>` off `origin/main` if it does not already exist:
+               - `git rev-parse --verify --quiet "refs/heads/milestone/<ms-slug>" || git branch "milestone/<ms-slug>" origin/main`
+             - Optionally create a worktree at `$HOME/.worktrees/{owner}/{repo}/milestone/<ms-slug>` and work there for the scaffold step
+             - Skip silently if the branch already exists
+
+          6. **Scaffold `docs/milestones/M<N>-<ms-slug>/`**
+             - On the `milestone/<ms-slug>` branch, create the directory if missing and add four files (stubs are fine):
+               - `press-release.md` — stub (will be filled in by `write_press_release`)
+               - `internal-faq.md` — stub (will be filled in by `write_internal_faq`)
+               - `designs.md` — stub
+               - `milestone.yaml` — written now with this schema:
+                 ```yaml
+                 slug: <ms-slug>
+                 forgejoMilestone: <N>
+                 forgejoIssue: <issue-#>
+                 flag: VEGA_FLAG_MILESTONE_<SLUG_UPPER>
+                 dependsOnSpecs: []
+                 status: planned
+                 ```
+             - `<SLUG_UPPER>` converts hyphens in `<ms-slug>` to underscores and uppercases (e.g., `eval-harness` -> `EVAL_HARNESS`)
+             - Commit: `git add docs/milestones/M<N>-<ms-slug>/ && git commit -m "docs(milestone): scaffold M<N>-<ms-slug> directory"`
+             - Push: `git push -u origin milestone/<ms-slug>`
+
+          7. **Update or create the stories issue**
+             - The issue title MUST be `Milestone: <ms-slug>` (drop any `(M#)` or `— consolidated user stories` suffix)
              - Build the issue body with two sections:
                1. If a press release preceded this milestone, embed its full text under a `## Press Release` heading at the top of the issue body. This is the working-backwards doc that scoped the milestone — reviewers must be able to read it directly on the issue. Do NOT link to vault file paths (private, invisible to reviewers).
                2. Below the press release (or at the top if no press release), include all refined stories from `refined_stories.md` under a `## User Stories` heading.
              - If `issue_number` is provided:
-               - GitHub: `gh issue edit <number> --repo owner/repo --body "BODY"`
-               - Update the issue title to "[Milestone Title]: User Stories for Review"
-               - Add the `product` label to the issue
+               - GitHub: `gh issue edit <number> --repo owner/repo --title "Milestone: <ms-slug>" --body "BODY"`
+               - Add the `kind:milestone` and `product` labels to the issue
                - Set the milestone on the issue
                - Assign to the business agent's account
              - If `issue_number` is blank:
-               - Title: "[Milestone Title]: User Stories for Review"
-               - GitHub: `gh issue create --repo owner/repo --title "TITLE" --body "BODY" --label "product" --milestone "MILESTONE"`
+               - GitHub: `gh issue create --repo owner/repo --title "Milestone: <ms-slug>" --body "BODY" --label "kind:milestone" --label "product" --milestone "Milestone: <ms-slug>"`
                - Assign to the business agent's account
+             - Record the resulting issue number — it goes into `forgejoIssue` in `milestone.yaml` (re-edit and commit the yaml if the issue was newly created in this step)
 
-          6. **Verify the setup**
+          8. **Verify the setup**
              - Confirm the milestone exists and the issue is linked to it
-             - Confirm labels are applied
+             - Confirm `kind:milestone` and `product` labels are applied
+             - Confirm the `milestone/<ms-slug>` branch exists on origin and `docs/milestones/M<N>-<ms-slug>/milestone.yaml` is committed
              - Record all URLs and numbers
 
           ## Output Format
@@ -1808,26 +1847,36 @@ workflows:
 
           ## Milestone
 
-          - **Title**: [milestone title]
-          - **Number**: [milestone number]
+          - **Slug**: [ms-slug]
+          - **Title**: Milestone: [ms-slug]
+          - **Number**: [milestone number — this is the M<N> in the docs dir]
           - **URL**: [milestone URL]
           - **Status**: [created | already existed]
+
+          ## Repo Scaffold
+
+          - **Branch**: milestone/[ms-slug] — [created | already existed]
+          - **Docs directory**: docs/milestones/M[N]-[ms-slug]/
+          - **Files**: press-release.md (stub), internal-faq.md (stub), designs.md (stub), milestone.yaml
+          - **Feature flag**: VEGA_FLAG_MILESTONE_[SLUG_UPPER]
 
           ## Issue
 
           - **Number**: [issue number]
-          - **Title**: [issue title]
+          - **Title**: Milestone: [ms-slug]
           - **URL**: [issue URL]
           - **Status**: [updated | created]
-          - **Labels**: [comma-separated labels applied]
+          - **Labels**: kind:milestone, product, [others]
           - **Assigned To**: [agent username]
 
           ## Actions Taken
 
-          1. [Description of each action, e.g., "Created milestone 'Homelab Monitoring Stack'"]
-          2. [e.g., "Updated issue #42 body with 4 refined user stories"]
-          3. [e.g., "Added user-story label to issue #42"]
-          4. [e.g., "Linked issue #42 to milestone #3"]
+          1. [Description of each action, e.g., "Created milestone 'Milestone: eval-harness'"]
+          2. [e.g., "Created branch milestone/eval-harness off origin/main"]
+          3. [e.g., "Scaffolded docs/milestones/M5-eval-harness/ with milestone.yaml"]
+          4. [e.g., "Retitled issue #42 to 'Milestone: eval-harness'"]
+          5. [e.g., "Added kind:milestone label to issue #42"]
+          6. [e.g., "Linked issue #42 to milestone"]
 
           ## Platform
 
@@ -1837,22 +1886,24 @@ workflows:
 
           ## Quality Criteria
 
-          - A milestone was found or created and its title and URL are recorded
-          - The issue is associated with the milestone
-          - The issue body was updated with the refined user stories in standard format
-          - The `product` label is on the issue
-          - The report includes milestone title, issue number, and URLs
-          - The `product` and `engineering` labels exist on the repo for future use
+          - A milestone was found or created with title `Milestone: <ms-slug>` and its URL is recorded
+          - The `milestone/<ms-slug>` branch exists on origin (created off main, or skipped because it already existed)
+          - `docs/milestones/M<N>-<ms-slug>/` exists with `press-release.md`, `internal-faq.md`, `designs.md`, and a populated `milestone.yaml` (schema fields: slug, forgejoMilestone, forgejoIssue, flag, dependsOnSpecs, status)
+          - The stories issue is titled `Milestone: <ms-slug>` (no `(M#) — consolidated user stories` suffix)
+          - The issue body contains the refined user stories
+          - The `kind:milestone` and `product` labels are on the issue
+          - The report includes milestone title, issue number, branch name, docs directory, and URLs
+          - The `kind:milestone`, `kind:spec`, `kind:spike`, `product`, and `engineering` labels exist on the repo for future use
 
           ## Next Steps
 
           After this workflow completes, suggest the following to the user:
 
-          > The milestone and user stories are ready. The natural next step is to run **`project/milestone_engineering_handoff`** to produce an internal FAQ, conduct the document review, create functional requirement specs, and create a single plan issue tracking all implementation work.
+          > The milestone, branch, and docs scaffold are ready. The natural next step is to run **`project/milestone_engineering_handoff`** to produce an internal FAQ, conduct the document review, create one or more `spec/<spec-slug>` branches with functional requirement specs, and create a single plan issue tracking all implementation work.
 
           ## Context
 
-          This is the final step that makes everything concrete on the platform. After this step, a human can review the consolidated issue, comment on individual stories, and approve them before agents begin work. The milestone provides the tracking container, and the issue serves as the parent scope document.
+          This is the step that makes the milestone concrete on the platform AND in the repo. After this step, a human can review the consolidated `Milestone:` issue, comment on individual stories, and approve them before agents begin spec work. The milestone provides the tracking container; the issue is the parent scope document; the `milestone/<ms-slug>` branch and `docs/milestones/M<N>-<ms-slug>/` directory are where the long-lived product docs (press release, internal FAQ, designs) and the `milestone.yaml` dependency declaration live. Specs are peer artifacts created downstream in `create_specs`.
         inputs:
           refined_stories: { required: true }
           milestone_title: { required: true }

--- a/deepwork/jobs/project/job.yml
+++ b/deepwork/jobs/project/job.yml
@@ -1365,8 +1365,20 @@ workflows:
               - Label the issue with `press-release` (create the label if it doesn't exist)
               - Record the **full URL** of the created issue in `.deepwork/tmp/<slug>-press-release-issue-url.md`
               - Update the zk note's `issue_ref` frontmatter field with the created issue URL
-              - If the project repo already stores press releases as tracked content, publish the finalized draft there as a separate explicit step after the issue is created
-              - If the project does not store press releases in-repo, keep `.deepwork/tmp/press_release.mdx` as the transient local artifact and treat the issue as the canonical published record
+
+          13. **Publish the canonical in-repo copy to the milestone directory**
+
+              Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md`), the canonical in-repo home for a milestone's press release is `docs/milestones/M<N>-<ms-slug>/press-release.md` on the `milestone/<ms-slug>` branch.
+
+              - If a milestone for this press release already exists (the user can supply `<ms-slug>` and the Forgejo milestone id `<N>`, or you can derive them from prior `setup_milestone` artifacts):
+                - Check out the `milestone/<ms-slug>` branch (or work in its worktree)
+                - Write the audience-facing press release content to `docs/milestones/M<N>-<ms-slug>/press-release.md`, replacing the stub created by `setup_milestone`
+                - Commit: `git commit -m "docs(milestone): publish press release for <ms-slug>"`
+                - Push: `git push origin milestone/<ms-slug>`
+              - If no milestone exists yet (the press release is running ahead of `setup_milestone`, which is normal — the press release URL feeds milestone setup):
+                - Keep `.deepwork/tmp/<slug>-press-release.mdx` as the transient handoff artifact
+                - Treat the published issue as the canonical record until `setup_milestone` runs
+                - `setup_milestone` will create the milestone dir with a press-release.md stub; either re-run this step with `<ms-slug>` + `<N>` supplied, or copy the press release content into `docs/milestones/M<N>-<ms-slug>/press-release.md` manually on the `milestone/<ms-slug>` branch as a separate explicit step
 
           ## Output Format
 
@@ -1375,9 +1387,9 @@ workflows:
           The finished press release in MDX format. Write the local workflow artifact to a
           unique path under `.deepwork/tmp/`, such as `.deepwork/tmp/keystone-project-agent-press-release.mdx`.
 
-          If the project already stores press releases in-repo, publish the finalized draft
-          to the project's designated directory, typically `posts/press_releases/`, as a
-          separate explicit publication step.
+          When a milestone exists, also publish the finalized press release as
+          `docs/milestones/M<N>-<ms-slug>/press-release.md` on the `milestone/<ms-slug>` branch
+          (see step 13). This is the canonical in-repo home per the milestone/spec convention.
 
           ### zk note in the configured notes dir
 
@@ -1484,6 +1496,7 @@ workflows:
           - The issue title follows the `Press Release: <Product Label>` format
           - The issue body has a human-readable context header above the first `---` — no jargon or internal tool names
           - The press release blockquote is enclosed between two `---` separators
+          - When a milestone is known (`<ms-slug>` + `<N>` supplied or derivable), the press release content has been written to `docs/milestones/M<N>-<ms-slug>/press-release.md` on the `milestone/<ms-slug>` branch and pushed
 
           ## Next Steps
 

--- a/deepwork/jobs/project/job.yml
+++ b/deepwork/jobs/project/job.yml
@@ -2351,11 +2351,20 @@ workflows:
 
           ## Objective
 
-          Write spec files grouped by system boundary, each containing behavioral requirements, data contracts, and edge case documentation. Commit specs to a branch, open a draft PR, and assign reviewers.
+          Write spec files for one engineering scope (one spec slug) covering one or more system boundaries. Each spec contains behavioral requirements, data contracts, and edge case documentation. Spec files land in `docs/specs/NNN-<spec-slug>/`. Commit specs to a `spec/<spec-slug>` branch off `main`, open a draft PR, and assign reviewers.
 
           ## Task
 
-          Read the scope analysis and review decision from prior steps, group approved stories by system boundary, and write spec files using RFC 2119 keywords. Each spec covers one system boundary and defines the behavioral requirements that implementation must satisfy. Only write specs for stories that are **in scope** or **renegotiated** per the review decision — deferred stories are excluded.
+          Read the scope analysis and review decision from prior steps, group approved stories under one engineering scope (one spec), and write spec files using RFC 2119 keywords. The spec slug is chosen for the engineering scope — it is NOT auto-derived from the milestone slug. One milestone may depend on multiple specs, each with its own slug. Only write specs for stories that are **in scope** or **renegotiated** per the review decision — deferred stories are excluded.
+
+          ### Spec slug vs milestone slug — convention reference
+
+          Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md` in the project repo when present), milestones and specs are **independent peers**, both branched off `main`:
+
+          - `milestone/<ms-slug>` — product integration, owns `docs/milestones/M<N>-<ms-slug>/`
+          - `spec/<spec-slug>` — engineering integration, owns `docs/specs/NNN-<spec-slug>/`
+
+          A milestone declares the specs it depends on in its `milestone.yaml` `dependsOnSpecs` array. A spec stands on its own and may be depended on by zero, one, or many milestones. Pick the spec slug to describe the engineering scope (e.g., `eval-cli-runner`, `mcp-transport-upgrade`), not the milestone.
 
           ### Process
 
@@ -2365,23 +2374,29 @@ workflows:
              - Extract the approved MVP scope — only in-scope and renegotiated stories
              - Note the system boundaries and the repository slug and platform
 
-          2. **Navigate to the project repo**
+          2. **Determine the spec slug**
+             - Ask the user (via `AskUserQuestion` if available) for the `<spec-slug>` describing this engineering scope. Suggest 1-2 candidate slugs based on the system boundaries in the scope analysis (e.g., `eval-cli-runner`, `recipe-search-index`).
+             - The slug MUST be kebab-case
+             - The slug is NOT auto-derived from the milestone slug — one milestone may have multiple specs with their own slugs
+             - If the user has a clear parent milestone slug from `setup_milestone`, ask whether this spec belongs to that milestone (used in the `create_plan_issue` step to update `milestone.yaml.dependsOnSpecs`)
+
+          3. **Navigate to the project repo**
              - Work in `.repos/{owner}/{repo}`
              - Ensure the repo is up to date: `git fetch origin`
 
-          3. **Create a branch and worktree**
-             - Derive a milestone slug from the milestone title (e.g., "Recipe Sharing Platform" -> `recipe-sharing-platform`)
-             - Create a branch: `git branch docs/specs-{milestone-slug} origin/main`
-             - Create a worktree: `git worktree add "$HOME/.worktrees/{owner}/{repo}/docs/specs-{milestone-slug}" docs/specs-{milestone-slug}`
+          4. **Create a branch and worktree**
+             - Create a branch off `origin/main` (NOT off the milestone branch — milestones and specs are peers): `git branch spec/<spec-slug> origin/main`
+             - Create a worktree: `git worktree add "$HOME/.worktrees/{owner}/{repo}/spec/<spec-slug>" spec/<spec-slug>`
              - Work in the worktree for all subsequent operations
 
-          4. **Create spec files**
-             - Create a `specs/` directory in the repo root (if it doesn't exist)
-             - For each system boundary identified in the scope analysis (for approved stories only), create a spec file at `specs/{NNN}-{slug}.md`
-             - Number specs sequentially: `001`, `002`, etc.
-             - The slug should be a short kebab-case name derived from the boundary name
+          5. **Create spec files**
+             - Find the next sequential spec number `NNN` by scanning existing `docs/specs/NNN-*/` directories — use the next free zero-padded integer (e.g., if `001`, `002`, `003` exist, use `004`). Numbers are stable and never reused.
+             - Create directory `docs/specs/NNN-<spec-slug>/` in the repo
+             - For each system boundary identified in the scope analysis (for approved stories only), create a spec file inside the directory at `docs/specs/NNN-<spec-slug>/<boundary-slug>.md`
+             - `<boundary-slug>` is a short kebab-case name derived from the boundary name (e.g., `api-layer.md`, `database-schema.md`)
+             - When only one boundary applies, a single `spec.md` inside the directory is also acceptable
 
-          5. **Write each spec**
+          6. **Write each spec**
              - For each spec file, include:
                - Which user stories this spec covers
                - Affected modules and files
@@ -2390,56 +2405,60 @@ workflows:
                - Edge cases and error handling
                - ASCII art mockups for UI components (if applicable)
              - For renegotiated stories, reflect the **revised** scope from the review decision — not the original press release promise
-             - Cross-reference other specs when boundaries interact
+             - Cross-reference other specs in the same directory or in peer `docs/specs/` directories when boundaries interact
 
-          6. **Commit and push**
-             - Stage all spec files: `git add specs/`
-             - Commit: `git commit -m "docs(specs): add functional requirement specs for {milestone}"`
-             - Push: `git push -u origin docs/specs-{milestone-slug}`
+          7. **Commit and push**
+             - Stage all spec files: `git add docs/specs/NNN-<spec-slug>/`
+             - Commit: `git commit -m "docs(specs): add NNN-<spec-slug> functional requirement specs"`
+             - Push: `git push -u origin spec/<spec-slug>`
 
-          7. **Open a draft PR**
+          8. **Open a draft PR**
 
              **GitHub**:
 
              ```bash
              gh pr create --draft \
-               --title "docs(specs): functional requirement specs for {milestone}" \
-               --body "Specs for milestone #{milestone_issue_number}. Review before implementation begins."
+               --title "docs(specs): NNN-<spec-slug> functional requirement specs" \
+               --body "Spec for engineering scope <spec-slug>. Review before implementation begins."
              ```
 
              **Forgejo**:
 
              ```bash
-             fj pr create "WIP: docs(specs): functional requirement specs for {milestone}" \
-               --head docs/specs-{milestone-slug} --base main \
-               --body "Specs for milestone #{milestone_issue_number}. Review before implementation begins." \
+             fj pr create "WIP: docs(specs): NNN-<spec-slug> functional requirement specs" \
+               --head spec/<spec-slug> --base main \
+               --body "Spec for engineering scope <spec-slug>. Review before implementation begins." \
                -r {owner}/{repo}
              ```
 
-          8. **Assign reviewers**
+          9. **Assign reviewers**
              - Read `.agents/TEAM.md` for the correct platform usernames
              - Assign Luce (CPO) and Nicholas (human) as reviewers
              - GitHub: `gh pr edit {pr_number} --add-reviewer {username1},{username2}`
              - Forgejo: use the API to add reviewers
 
-          9. **Write the specs PR report**
+          10. **Write the specs PR report**
+              - Capture the spec slug, directory path, parent milestone slug (if known) so `create_plan_issue` can update the right `milestone.yaml`
 
           ## Output Format
 
           ### specs_pr_report.md
 
-          A report documenting the created spec files and the draft PR.
+          A report documenting the created spec directory, spec files, and the draft PR.
 
           **Structure**:
 
           ```markdown
-          # Specs PR Report: [Milestone Title]
+          # Specs PR Report: [Spec Slug]
 
           ## Platform
 
           - **Platform**: [github | forgejo]
           - **Repository**: [owner/repo]
-          - **Branch**: docs/specs-[milestone-slug]
+          - **Branch**: spec/[spec-slug]
+          - **Spec Directory**: docs/specs/[NNN]-[spec-slug]/
+          - **Spec Slug**: [spec-slug]
+          - **Parent Milestone Slug** (if any): [ms-slug or "(orphan spec)"]
 
           ## Draft PR
 
@@ -2450,20 +2469,18 @@ workflows:
 
           ## Spec Files Created
 
-          | File                           | Boundary        | Stories Covered        |
-          | ------------------------------ | --------------- | ---------------------- |
-          | `specs/001-api-layer.md`       | API Layer       | US-001, US-002, US-003 |
-          | `specs/002-database-schema.md` | Database Schema | US-001, US-002, US-004 |
+          | File                                              | Boundary        | Stories Covered        |
+          | ------------------------------------------------- | --------------- | ---------------------- |
+          | `docs/specs/004-eval-harness/api-layer.md`        | API Layer       | US-001, US-002, US-003 |
+          | `docs/specs/004-eval-harness/database-schema.md`  | Database Schema | US-001, US-002, US-004 |
 
           ## Spec Summary
 
-          ### specs/001-api-layer.md
+          ### docs/specs/[NNN]-[spec-slug]/[boundary].md
 
-          - **Boundary**: API Layer
+          - **Boundary**: [boundary name]
           - **Key requirements**: [1-2 sentence summary of MUST requirements]
           - **Data contracts**: [list of API endpoints or models defined]
-
-          ### specs/002-database-schema.md
 
           ...
 
@@ -2474,17 +2491,20 @@ workflows:
 
           ## Quality Criteria
 
-          - Every system boundary identified in the scope analysis (for approved stories) has a corresponding spec file
+          - The spec slug was chosen for the engineering scope (not auto-derived from the milestone slug) and is kebab-case
+          - The `spec/<spec-slug>` branch was created off `origin/main` (not off `milestone/<ms-slug>` — milestones and specs are peers)
+          - Spec files live under `docs/specs/NNN-<spec-slug>/` with a fresh, never-reused `NNN`
+          - Every system boundary identified in the scope analysis (for approved stories) has a corresponding spec file under the spec directory
           - Specs use RFC 2119 keywords (MUST, SHOULD, MAY) for behavioral requirements
           - API contracts, data models, or interface definitions are specified where applicable
           - A draft PR has been created with the spec files and assigned to reviewers
           - Edge cases and error handling are documented in each spec
-          - Spec files are numbered sequentially and use kebab-case slugs
           - Specs reflect renegotiated scope from the review decision, not the original press release promises
+          - The report records the parent milestone slug (if any) so the next step can update `milestone.yaml.dependsOnSpecs`
 
           ## Context
 
-          This step bridges analysis and implementation planning. Specs serve as the contract between product and engineering: they define what the system must do (behavioral requirements) without prescribing how (implementation details). The specs PR goes through review before implementation starts, ensuring alignment between Luce (product), Nicholas (human), and Drago (engineering). Subsequent steps reference these specs when creating the plan issue.
+          This step bridges analysis and implementation planning. Specs serve as the contract between product and engineering: they define what the system must do (behavioral requirements) without prescribing how (implementation details). The `spec/<spec-slug>` branch is a peer to any `milestone/<ms-slug>` — both branch off `main`. Orphan specs (no milestone parent) are valid; they ship engineering work on their own merits. The specs PR goes through review before implementation starts, ensuring alignment between Luce (product), Nicholas (human), and Drago (engineering). The next step (`create_plan_issue`) creates the `Spec: <spec-slug>` tracking issue and, if a parent milestone was identified, updates that milestone's `milestone.yaml` to append `<spec-slug>` to `dependsOnSpecs`.
         inputs:
           scope_analysis: { required: true }
           review_decision: { required: true }

--- a/deepwork/jobs/project/steps/create_plan_issue.md
+++ b/deepwork/jobs/project/steps/create_plan_issue.md
@@ -1,26 +1,34 @@
-# Create Implementation Plan Issue
+# Create Spec Tracking Issue
 
 ## Objective
 
-Create a **single** plan issue on the milestone that serves as the sole tracking issue for all implementation work. This issue includes happy paths, test expectations, design mockups, demo artifacts, **and a phased task checklist documenting parallelism and blocking dependencies**. PRs are opened directly against this issue — no child issues are created.
+Create a **single** `Spec: <spec-slug>` tracking issue that serves as the sole tracking issue for all implementation work on this spec. This issue includes happy paths, test expectations, design mockups, demo artifacts, a "Used by milestones" reverse-lookup section, **and a phased task checklist documenting parallelism and blocking dependencies**. PRs are opened directly against this issue — no child issues are created. After the issue succeeds, append `<spec-slug>` to the parent milestone's `milestone.yaml` `dependsOnSpecs` (if a parent milestone was identified).
 
 ## Task
 
-Read the scope analysis, review decision, and specs PR report from prior steps, then compose and create one comprehensive plan issue on the project's platform. This issue becomes the single reference point for all implementation work on the milestone. Multiple PRs will reference this issue via `Part of #N` or `Closes #N`.
+Read the scope analysis, review decision, and specs PR report from prior steps, then compose and create one comprehensive `Spec:` issue on the project's platform. This issue becomes the single reference point for all implementation work tied to the spec. Multiple PRs will reference this issue via `Part of #N` or `Closes #N`.
 
 **IMPORTANT: Do NOT create child issues.** All work is tracked in this issue's task checklist.
 
-**ISSUE COUNT CAP**: Create exactly ONE plan issue. If you identify a genuinely distinct feature that warrants its own issue (large delineating feature, not just a subtask), you MUST stop and ask the human for approval before creating it. The absolute maximum is 1-3 additional issues, and each requires explicit human sign-off. Issue bloat (10+ issues per milestone) has been a recurring problem — err on fewer issues.
+**ISSUE COUNT CAP**: Create exactly ONE `Spec:` issue per spec. If you identify a genuinely distinct feature that warrants its own issue (large delineating feature, not just a subtask), you MUST stop and ask the human for approval before creating it. The absolute maximum is 1-3 additional issues, and each requires explicit human sign-off. Issue bloat (10+ issues per milestone) has been a recurring problem — err on fewer issues.
+
+### Convention reference — Spec issue title and labels
+
+Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md` in the project repo when present):
+
+- Title: `Spec: <spec-slug>` (e.g., `Spec: eval-cli-runner`). Do NOT use `Plan: <milestone title>` or `(M#)` suffixes.
+- Label: `kind:spec`
+- Body must include a **"Used by milestones"** section listing every milestone whose `milestone.yaml` `dependsOnSpecs` includes this spec, or `(none yet)` if no parent. Reviewers can derive the reverse-lookup at read time, but seeding it here gives the human-readable view on the issue itself.
 
 ### Process
 
 1. **Read prior step outputs**
    - Load `scope_analysis.md` — for the story-to-system map and prerequisites
    - Load `review_decision.md` — for the approved MVP scope (in scope + renegotiated stories only)
-   - Load `specs_pr_report.md` — for the specs PR number/URL and spec file details
-   - Extract the milestone title, issue number, and platform
+   - Load `specs_pr_report.md` — for the spec slug, spec directory path, specs PR number/URL, parent milestone slug (if any), and spec file details
+   - Extract the platform and repo
 
-2. **Compose the plan issue body**
+2. **Compose the spec issue body**
    For each **approved** user story from the review decision, include:
    - **Happy path requirements** — the expected user flow when everything works correctly
    - **Red/green test expectations** — what test should fail before implementation (red) and pass after (green). Be specific about the assertion, not just "it should work."
@@ -30,9 +38,32 @@ Read the scope analysis, review decision, and specs PR report from prior steps, 
    Also include:
    - **Implementation order** — which stories can be parallelized and which have dependencies
    - **Feature flag requirements** — which stories need feature flags for safe deployment
-   - References to the specs PR, the review decision, and the original milestone issue
+   - References to the specs PR, the review decision, and the parent milestone issue (if any)
+   - A **"Used by milestones"** section (see step 3)
 
-3. **Compose the phased task checklist**
+3. **Compose the "Used by milestones" section**
+
+   Scan every `docs/milestones/*/milestone.yaml` in the repo for entries whose `dependsOnSpecs` already contains `<spec-slug>`:
+
+   ```bash
+   # In the project repo, on main:
+   for f in docs/milestones/*/milestone.yaml; do
+     yq -r 'select(.dependsOnSpecs[]? == "<spec-slug>") | .slug + " (" + .forgejoIssue + ")"' "$f"
+   done
+   ```
+
+   Render the result inside the issue body:
+
+   ```markdown
+   ## Used by milestones
+
+   - eval-harness (#10)
+   - cli-onboarding (#23)
+   ```
+
+   If no milestones currently depend on this spec, render `(none yet)`. Note that this step's later sub-step (step 6) will add the parent milestone declared at workflow start, so the reverse-lookup will be live as soon as that yaml is committed.
+
+4. **Compose the phased task checklist**
 
    Break the work into tasks grouped by phase. Each task should map to a single small PR (2-3 files max). Use conventional commit prefixes for task names. Document parallelism and blocking:
 
@@ -53,7 +84,7 @@ Read the scope analysis, review decision, and specs PR report from prior steps, 
 
    - [ ] test: add recipe API integration tests
 
-   ### Future Work (out of milestone scope)
+   ### Future Work (out of spec scope)
 
    - Recipe ratings and reviews
    - Recipe import from external sites
@@ -65,65 +96,85 @@ Read the scope analysis, review decision, and specs PR report from prior steps, 
    - Feature tasks should depend on infrastructure, not on each other
    - Use feature flags to avoid blocking on deployment order
 
-4. **Create the plan issue**
+5. **Create the spec issue**
 
    **GitHub**:
 
    ```bash
    gh issue create --repo {owner}/{repo} \
-     --title "Plan: {milestone title}" \
+     --title "Spec: <spec-slug>" \
      --body "$BODY" \
-     --label "engineering" --label "plan" \
-     --milestone "{milestone title}" \
+     --label "kind:spec" --label "engineering" \
      --assignee {drago_username}
    ```
 
    **Forgejo**:
 
    ```bash
-   fj issue create "Plan: {milestone title}" \
+   fj issue create "Spec: <spec-slug>" \
      --body "$BODY" \
-     --label "engineering" --label "plan" \
+     --label "kind:spec" --label "engineering" \
      -r {owner}/{repo}
    ```
 
-   Then link to milestone and assign via API.
-   - Ensure `engineering` and `plan` labels exist (create if missing)
+   Then assign via API.
+   - Ensure `kind:spec` and `engineering` labels exist (create if missing)
    - Assign to Drago (CTO) — read username from `.agents/TEAM.md`
-   - Link to the milestone
+   - The `Spec:` issue is NOT linked to a Forgejo milestone — the milestone-spec relationship lives in `milestone.yaml.dependsOnSpecs` (the next step), and the parent milestone issue cross-references the spec issue in its own body.
 
-5. **Write the plan issue report**
+6. **Update the parent milestone's `milestone.yaml`** (if a parent milestone was named at workflow start)
+
+   On the `milestone/<ms-slug>` branch (or in its worktree), append `<spec-slug>` to `dependsOnSpecs` in `docs/milestones/M<N>-<ms-slug>/milestone.yaml`. Skip this step entirely if the spec is orphan (no parent milestone).
+
+   ```bash
+   # In the milestone worktree:
+   yq -i ".dependsOnSpecs += [\"<spec-slug>\"] | .dependsOnSpecs |= unique" \
+     docs/milestones/M<N>-<ms-slug>/milestone.yaml
+   git add docs/milestones/M<N>-<ms-slug>/milestone.yaml
+   git commit -m "docs(milestone): depend on spec <spec-slug>"
+   git push origin milestone/<ms-slug>
+   ```
+
+   Use `unique` to avoid duplicate entries on re-runs.
+
+7. **Write the plan issue report**
+   - Record whether the parent milestone yaml was updated (and the resulting `dependsOnSpecs` list), or "no parent milestone — orphan spec"
 
 ## Output Format
 
 ### plan_issue_report.md
 
-A report documenting the created plan issue.
+A report documenting the created spec issue.
 
 **Structure**:
 
 ```markdown
-# Plan Issue Report: [Milestone Title]
+# Spec Issue Report: [Spec Slug]
 
 ## Platform
 
 - **Platform**: [github | forgejo]
 - **Repository**: [owner/repo]
 
-## Plan Issue
+## Spec Issue
 
 - **Number**: #[number]
-- **Title**: Plan: [milestone title]
+- **Title**: Spec: [spec-slug]
 - **URL**: [issue URL]
-- **Milestone**: [milestone title]
 - **Assignee**: [Drago's username]
-- **Labels**: engineering, plan
+- **Labels**: kind:spec, engineering
 
 ## References
 
-- **Milestone Issue**: #[milestone_issue_number]
+- **Parent Milestone Issue**: #[milestone_issue_number] (or "(orphan spec)")
 - **Specs PR**: #[specs_pr_number] ([URL])
 - **Review Decision**: [link or summary]
+
+## Used by milestones (committed to milestone.yaml)
+
+- [ms-slug] (#[issue]) — appended by this step
+- [other-ms-slug] (#[issue]) — pre-existing
+(or: "(none yet) — orphan spec")
 
 ## Stories Included
 
@@ -145,16 +196,22 @@ A report documenting the created plan issue.
 [Any issues or items needing attention]
 ```
 
-### Plan Issue Body Format
+### Spec Issue Body Format
 
 The issue body created on the platform should follow this structure:
 
 ```markdown
-# Plan: [Milestone Title]
+# Spec: [spec-slug]
 
-**Milestone Issue**: #[milestone_issue_number]
+**Spec Directory**: docs/specs/[NNN]-[spec-slug]/
 **Specs PR**: #[specs_pr_number]
+**Parent Milestone Issue**: #[milestone_issue_number] (or omit if orphan)
 **Review Decision**: [link or inline summary of scope decisions]
+
+## Used by milestones
+
+- [ms-slug] (#[issue])
+(or: "(none yet)")
 
 ## Stories
 
@@ -217,7 +274,7 @@ The issue body created on the platform should follow this structure:
 ### Phase 3: Integration Tests (depends on Phase 2)
 - [ ] test: add recipe API integration tests
 
-### Future Work (out of milestone scope)
+### Future Work (out of spec scope)
 - Recipe ratings and reviews
 - Recipe import from external sites
 
@@ -232,25 +289,28 @@ The issue body created on the platform should follow this structure:
 
 ## Quality Criteria
 
-- **No child issues created** — all work tracked in this single plan issue's task checklist
-- Every approved user story from the review decision appears in the plan with happy path requirements
+- The issue title is `Spec: <spec-slug>` (NOT `Plan: <milestone title>`; NO `(M#)` suffix)
+- The `kind:spec` and `engineering` labels are applied
+- **No child issues created** — all work tracked in this single spec issue's task checklist
+- A "Used by milestones" section is present (with either parent milestone entries or `(none yet)`)
+- If a parent milestone was named at workflow start, that milestone's `milestone.yaml` was updated to append `<spec-slug>` to `dependsOnSpecs` and committed/pushed on `milestone/<ms-slug>`
+- Every approved user story from the review decision appears in the issue with happy path requirements
 - A phased task checklist documents all work items with conventional commit prefixes
 - Parallelism and blocking dependencies are clearly documented per phase
 - Each story includes red/green test expectations describing what fails before and passes after implementation
 - ASCII art mockups are included for new UI components or layouts
 - Expected demo artifacts are described for each story (screenshots, videos, preview URLs)
-- The specs PR is referenced in the plan issue body
-- The plan issue is linked to the milestone
+- The specs PR and the spec directory path are referenced in the issue body
 
 ## After this step
 
-Once the plan issue is created, suggest the following to the user:
+Once the spec issue is created, suggest the following to the user:
 
-> The plan issue is ready. Next steps:
+> The `Spec: <spec-slug>` issue is ready. Next steps:
 >
-> 1. **`engineer/implement`** — use this workflow for each task in the plan checklist to drive implementation through to merged PRs.
+> 1. **`engineer/implement`** — use this workflow for each task in the spec issue's task checklist to drive implementation through to merged PRs. Per-task PRs target `spec/<spec-slug>`; `spec/<spec-slug>` merges to `main` when engineering is complete.
 > 2. **`ks.notes` / `notes/process_inbox`** — capture the scope analysis, design decisions, and review outcome into personal notes before implementation begins. Key decisions made during the document review are worth preserving in the Zettelkasten.
 
 ## Context
 
-This step creates the engineering blueprint for the milestone. The plan issue serves as the **single tracking issue** for all implementation work — no child issues are created. Instead, the plan issue contains a phased task checklist where each task maps to one PR. This avoids issue sprawl (10+ granular issues per milestone) and keeps all context, parallelism notes, and blocking info in one place. PRs reference the plan issue with `Part of #N`. The test expectations follow TDD principles — defining what should fail and pass before writing code. The demo artifacts ensure that every story has a verifiable outcome visible to stakeholders.
+This step creates the engineering tracking issue for the spec. The `Spec:` issue serves as the **single tracking issue** for all implementation work tied to this engineering scope — no child issues are created. Instead, it contains a phased task checklist where each task maps to one PR. This avoids issue sprawl (10+ granular issues per milestone) and keeps all context, parallelism notes, and blocking info in one place. PRs reference the spec issue with `Part of #N`. The test expectations follow TDD principles — defining what should fail and pass before writing code. The demo artifacts ensure that every story has a verifiable outcome visible to stakeholders. The "Used by milestones" section and the `milestone.yaml.dependsOnSpecs` update are the two halves of the milestone-spec link: one for humans reading the issue, one for tooling reading the yaml.

--- a/deepwork/jobs/project/steps/create_specs.md
+++ b/deepwork/jobs/project/steps/create_specs.md
@@ -2,11 +2,20 @@
 
 ## Objective
 
-Write spec files grouped by system boundary, each containing behavioral requirements, data contracts, and edge case documentation. Commit specs to a branch, open a draft PR, and assign reviewers.
+Write spec files for one engineering scope (one spec slug) covering one or more system boundaries. Each spec contains behavioral requirements, data contracts, and edge case documentation. Spec files land in `docs/specs/NNN-<spec-slug>/`. Commit specs to a `spec/<spec-slug>` branch off `main`, open a draft PR, and assign reviewers.
 
 ## Task
 
-Read the scope analysis and review decision from prior steps, group approved stories by system boundary, and write spec files using RFC 2119 keywords. Each spec covers one system boundary and defines the behavioral requirements that implementation must satisfy. Only write specs for stories that are **in scope** or **renegotiated** per the review decision — deferred stories are excluded.
+Read the scope analysis and review decision from prior steps, group approved stories under one engineering scope (one spec), and write spec files using RFC 2119 keywords. The spec slug is chosen for the engineering scope — it is NOT auto-derived from the milestone slug. One milestone may depend on multiple specs, each with its own slug. Only write specs for stories that are **in scope** or **renegotiated** per the review decision — deferred stories are excluded.
+
+### Spec slug vs milestone slug — convention reference
+
+Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md` in the project repo when present), milestones and specs are **independent peers**, both branched off `main`:
+
+- `milestone/<ms-slug>` — product integration, owns `docs/milestones/M<N>-<ms-slug>/`
+- `spec/<spec-slug>` — engineering integration, owns `docs/specs/NNN-<spec-slug>/`
+
+A milestone declares the specs it depends on in its `milestone.yaml` `dependsOnSpecs` array. A spec stands on its own and may be depended on by zero, one, or many milestones. Pick the spec slug to describe the engineering scope (e.g., `eval-cli-runner`, `mcp-transport-upgrade`), not the milestone.
 
 ### Process
 
@@ -16,23 +25,29 @@ Read the scope analysis and review decision from prior steps, group approved sto
    - Extract the approved MVP scope — only in-scope and renegotiated stories
    - Note the system boundaries and the repository slug and platform
 
-2. **Navigate to the project repo**
+2. **Determine the spec slug**
+   - Ask the user (via `AskUserQuestion` if available) for the `<spec-slug>` describing this engineering scope. Suggest 1-2 candidate slugs based on the system boundaries in the scope analysis (e.g., `eval-cli-runner`, `recipe-search-index`).
+   - The slug MUST be kebab-case
+   - The slug is NOT auto-derived from the milestone slug — one milestone may have multiple specs with their own slugs
+   - If the user has a clear parent milestone slug from `setup_milestone`, ask whether this spec belongs to that milestone (used in the `create_plan_issue` step to update `milestone.yaml.dependsOnSpecs`)
+
+3. **Navigate to the project repo**
    - Work in `.repos/{owner}/{repo}`
    - Ensure the repo is up to date: `git fetch origin`
 
-3. **Create a branch and worktree**
-   - Derive a milestone slug from the milestone title (e.g., "Recipe Sharing Platform" → `recipe-sharing-platform`)
-   - Create a branch: `git branch docs/specs-{milestone-slug} origin/main`
-   - Create a worktree: `git worktree add "$HOME/.worktrees/{owner}/{repo}/docs/specs-{milestone-slug}" docs/specs-{milestone-slug}`
+4. **Create a branch and worktree**
+   - Create a branch off `origin/main` (NOT off the milestone branch — milestones and specs are peers): `git branch spec/<spec-slug> origin/main`
+   - Create a worktree: `git worktree add "$HOME/.worktrees/{owner}/{repo}/spec/<spec-slug>" spec/<spec-slug>`
    - Work in the worktree for all subsequent operations
 
-4. **Create spec files**
-   - Create a `specs/` directory in the repo root (if it doesn't exist)
-   - For each system boundary identified in the scope analysis (for approved stories only), create a spec file at `specs/{NNN}-{slug}.md`
-   - Number specs sequentially: `001`, `002`, etc.
-   - The slug should be a short kebab-case name derived from the boundary name
+5. **Create spec files**
+   - Find the next sequential spec number `NNN` by scanning existing `docs/specs/NNN-*/` directories — use the next free zero-padded integer (e.g., if `001`, `002`, `003` exist, use `004`). Numbers are stable and never reused.
+   - Create directory `docs/specs/NNN-<spec-slug>/` in the repo
+   - For each system boundary identified in the scope analysis (for approved stories only), create a spec file inside the directory at `docs/specs/NNN-<spec-slug>/<boundary-slug>.md`
+   - `<boundary-slug>` is a short kebab-case name derived from the boundary name (e.g., `api-layer.md`, `database-schema.md`)
+   - When only one boundary applies, a single `spec.md` inside the directory is also acceptable
 
-5. **Write each spec**
+6. **Write each spec**
    - For each spec file, include:
      - Which user stories this spec covers
      - Affected modules and files
@@ -41,56 +56,60 @@ Read the scope analysis and review decision from prior steps, group approved sto
      - Edge cases and error handling
      - ASCII art mockups for UI components (if applicable)
    - For renegotiated stories, reflect the **revised** scope from the review decision — not the original press release promise
-   - Cross-reference other specs when boundaries interact
+   - Cross-reference other specs in the same directory or in peer `docs/specs/` directories when boundaries interact
 
-6. **Commit and push**
-   - Stage all spec files: `git add specs/`
-   - Commit: `git commit -m "docs(specs): add functional requirement specs for {milestone}"`
-   - Push: `git push -u origin docs/specs-{milestone-slug}`
+7. **Commit and push**
+   - Stage all spec files: `git add docs/specs/NNN-<spec-slug>/`
+   - Commit: `git commit -m "docs(specs): add NNN-<spec-slug> functional requirement specs"`
+   - Push: `git push -u origin spec/<spec-slug>`
 
-7. **Open a draft PR**
+8. **Open a draft PR**
 
    **GitHub**:
 
    ```bash
    gh pr create --draft \
-     --title "docs(specs): functional requirement specs for {milestone}" \
-     --body "Specs for milestone #{milestone_issue_number}. Review before implementation begins."
+     --title "docs(specs): NNN-<spec-slug> functional requirement specs" \
+     --body "Spec for engineering scope <spec-slug>. Review before implementation begins."
    ```
 
    **Forgejo**:
 
    ```bash
-   fj pr create "WIP: docs(specs): functional requirement specs for {milestone}" \
-     --head docs/specs-{milestone-slug} --base main \
-     --body "Specs for milestone #{milestone_issue_number}. Review before implementation begins." \
+   fj pr create "WIP: docs(specs): NNN-<spec-slug> functional requirement specs" \
+     --head spec/<spec-slug> --base main \
+     --body "Spec for engineering scope <spec-slug>. Review before implementation begins." \
      -r {owner}/{repo}
    ```
 
-8. **Assign reviewers**
+9. **Assign reviewers**
    - Read `.agents/TEAM.md` for the correct platform usernames
    - Assign Luce (CPO) and Nicholas (human) as reviewers
    - GitHub: `gh pr edit {pr_number} --add-reviewer {username1},{username2}`
    - Forgejo: use the API to add reviewers
 
-9. **Write the specs PR report**
+10. **Write the specs PR report**
+    - Capture the spec slug, directory path, parent milestone slug (if known) so `create_plan_issue` can update the right `milestone.yaml`
 
 ## Output Format
 
 ### specs_pr_report.md
 
-A report documenting the created spec files and the draft PR.
+A report documenting the created spec directory, spec files, and the draft PR.
 
 **Structure**:
 
 ```markdown
-# Specs PR Report: [Milestone Title]
+# Specs PR Report: [Spec Slug]
 
 ## Platform
 
 - **Platform**: [github | forgejo]
 - **Repository**: [owner/repo]
-- **Branch**: docs/specs-[milestone-slug]
+- **Branch**: spec/[spec-slug]
+- **Spec Directory**: docs/specs/[NNN]-[spec-slug]/
+- **Spec Slug**: [spec-slug]
+- **Parent Milestone Slug** (if any): [ms-slug or "(orphan spec)"]
 
 ## Draft PR
 
@@ -101,21 +120,19 @@ A report documenting the created spec files and the draft PR.
 
 ## Spec Files Created
 
-| File                           | Boundary        | Stories Covered        |
-| ------------------------------ | --------------- | ---------------------- |
-| `specs/001-api-layer.md`       | API Layer       | US-001, US-002, US-003 |
-| `specs/002-database-schema.md` | Database Schema | US-001, US-002, US-004 |
-| `specs/003-auth-middleware.md` | Auth Middleware | US-003, US-005         |
+| File                                              | Boundary        | Stories Covered        |
+| ------------------------------------------------- | --------------- | ---------------------- |
+| `docs/specs/004-eval-harness/api-layer.md`        | API Layer       | US-001, US-002, US-003 |
+| `docs/specs/004-eval-harness/database-schema.md`  | Database Schema | US-001, US-002, US-004 |
+| `docs/specs/004-eval-harness/auth-middleware.md`  | Auth Middleware | US-003, US-005         |
 
 ## Spec Summary
 
-### specs/001-api-layer.md
+### docs/specs/[NNN]-[spec-slug]/[boundary].md
 
-- **Boundary**: API Layer
+- **Boundary**: [boundary name]
 - **Key requirements**: [1-2 sentence summary of MUST requirements]
 - **Data contracts**: [list of API endpoints or models defined]
-
-### specs/002-database-schema.md
 
 ...
 
@@ -126,7 +143,7 @@ A report documenting the created spec files and the draft PR.
 
 ### Spec File Format
 
-Each spec file at `specs/{NNN}-{slug}.md` should follow this structure:
+Each spec file at `docs/specs/{NNN}-{spec-slug}/{boundary}.md` should follow this structure:
 
 ````markdown
 # Spec: [Boundary Name]
@@ -211,14 +228,17 @@ Each spec file at `specs/{NNN}-{slug}.md` should follow this structure:
 
 ## Quality Criteria
 
-- Every system boundary identified in the scope analysis (for approved stories) has a corresponding spec file
+- The spec slug was chosen for the engineering scope (not auto-derived from the milestone slug) and is kebab-case
+- The `spec/<spec-slug>` branch was created off `origin/main` (not off `milestone/<ms-slug>` — milestones and specs are peers)
+- Spec files live under `docs/specs/NNN-<spec-slug>/` with a fresh, never-reused `NNN`
+- Every system boundary identified in the scope analysis (for approved stories) has a corresponding spec file under the spec directory
 - Specs use RFC 2119 keywords (MUST, SHOULD, MAY) for behavioral requirements
 - API contracts, data models, or interface definitions are specified where applicable
 - A draft PR has been created with the spec files and assigned to reviewers
 - Edge cases and error handling are documented in each spec
-- Spec files are numbered sequentially and use kebab-case slugs
 - Specs reflect renegotiated scope from the review decision, not the original press release promises
+- The report records the parent milestone slug (if any) so the next step can update `milestone.yaml.dependsOnSpecs`
 
 ## Context
 
-This step bridges analysis and implementation planning. Specs serve as the contract between product and engineering: they define what the system must do (behavioral requirements) without prescribing how (implementation details). The specs PR goes through review before implementation starts, ensuring alignment between Luce (product), Nicholas (human), and Drago (engineering). Subsequent steps reference these specs when creating the plan issue.
+This step bridges analysis and implementation planning. Specs serve as the contract between product and engineering: they define what the system must do (behavioral requirements) without prescribing how (implementation details). The `spec/<spec-slug>` branch is a peer to any `milestone/<ms-slug>` — both branch off `main`. Orphan specs (no milestone parent) are valid; they ship engineering work on their own merits. The specs PR goes through review before implementation starts, ensuring alignment between Luce (product), Nicholas (human), and Drago (engineering). The next step (`create_plan_issue`) creates the `Spec: <spec-slug>` tracking issue and, if a parent milestone was identified, updates that milestone's `milestone.yaml` to append `<spec-slug>` to `dependsOnSpecs`.

--- a/deepwork/jobs/project/steps/setup_milestone.md
+++ b/deepwork/jobs/project/steps/setup_milestone.md
@@ -2,11 +2,21 @@
 
 ## Objective
 
-Check if a milestone already exists for this scope, create one if needed, update the issue body with refined user stories, and link the issue to the milestone.
+Check if a milestone already exists for this scope, create one if needed, scaffold the in-repo milestone directory (`docs/milestones/M<N>-<ms-slug>/`) and long-lived `milestone/<ms-slug>` branch, update the issue body with refined user stories, and link the issue to the milestone.
 
 ## Task
 
-Using the refined stories and milestone title from the previous step, set up the milestone and issue on the project's platform (GitHub or Forgejo).
+Using the refined stories and milestone title from the previous step, set up the milestone and issue on the project's platform (GitHub or Forgejo) and scaffold the per-milestone docs/branch artifacts per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md` in the project repo when present).
+
+### Branch types — convention reference
+
+Per the milestone/spec convention, the repo has three long-lived branch types, all peers off `main`:
+
+- `milestone/<ms-slug>` — product integration branch carrying `docs/milestones/M<N>-<ms-slug>/`
+- `spec/<spec-slug>` — engineering integration branch carrying `docs/specs/NNN-<spec-slug>/`
+- `spike/<spike-slug>` — short-lived investigation branch whose findings flow into a spec's `research.md` (or as a note on a parent `Spec:` issue) and is then typically discarded
+
+This step creates the milestone branch. Spec branches are created in `create_specs`. Spikes are created ad hoc by the engineer (e.g., via `engineer/implement` or manually) when an investigation is needed; this workflow does not create them automatically.
 
 ### Process
 
@@ -17,41 +27,70 @@ Using the refined stories and milestone title from the previous step, set up the
 2. **Check for existing milestone**
    - GitHub: `gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.title == "TITLE") | .number'`
    - Forgejo: `tea api /repos/{owner}/{repo}/milestones` or equivalent curl
+   - The milestone title MUST be `Milestone: <ms-slug>` (e.g., `Milestone: eval-harness`). Do NOT use the `(M#) — consolidated user stories` suffix — the `kind:milestone` label and unique slug carry kind and identity.
    - If a matching milestone exists, use it (record its number and URL)
    - If no match, create a new milestone
 
 3. **Create milestone (if needed)**
-   - GitHub: `gh api repos/{owner}/{repo}/milestones -f title="TITLE" -f description="DESCRIPTION"`
+   - GitHub: `gh api repos/{owner}/{repo}/milestones -f title="Milestone: <ms-slug>" -f description="DESCRIPTION"`
    - Forgejo: `tea api -X POST /repos/{owner}/{repo}/milestones` with title and description
    - The milestone description MUST be a short summary (2-3 sentences max). GitHub/Forgejo milestone descriptions are collapsed by default — long content is hidden behind a click.
    - The description MUST include both **why** (the problem or motivation) and **what** (the deliverable). Lead with the why — it gives reviewers instant context on the business reason for the milestone.
    - Example: "Developers lose minutes every day switching between projects across scattered terminals and workspaces. This milestone delivers a unified context system for launching, naming, and switching between scoped work environments. User stories: #174"
+   - Record the Forgejo/GitHub milestone id `<N>` — it becomes the `M<N>` prefix in `docs/milestones/M<N>-<ms-slug>/`.
 
 4. **Ensure required labels exist**
-   - Check that `product` and `engineering` labels exist on the repo
+   - Check that `kind:milestone`, `kind:spec`, `kind:spike`, `product`, and `engineering` labels exist on the repo
    - Create any missing labels:
-     - GitHub: `gh label create "product" --repo owner/repo --description "Product story" --color "0E8A16"`
+     - GitHub: `gh label create "kind:milestone" --repo owner/repo --description "Milestone tracking issue" --color "5319E7"`
      - Forgejo: equivalent API call
    - Use sensible default colors if creating
 
-5. **Update or create the issue**
+5. **Create the long-lived milestone branch**
+   - Derive `<ms-slug>` (kebab-case) from the milestone title (e.g., "Eval Harness" -> `eval-harness`)
+   - Ensure local main is current: `git fetch origin && git checkout main && git pull --ff-only`
+   - Create branch `milestone/<ms-slug>` off `origin/main` if it does not already exist:
+     - `git rev-parse --verify --quiet "refs/heads/milestone/<ms-slug>" || git branch "milestone/<ms-slug>" origin/main`
+   - Optionally create a worktree at `$HOME/.worktrees/{owner}/{repo}/milestone/<ms-slug>` and work there for the scaffold step
+   - Skip silently if the branch already exists
+
+6. **Scaffold `docs/milestones/M<N>-<ms-slug>/`**
+   - On the `milestone/<ms-slug>` branch, create the directory if missing and add four files (stubs are fine):
+     - `press-release.md` — stub (will be filled in by `write_press_release`)
+     - `internal-faq.md` — stub (will be filled in by `write_internal_faq`)
+     - `designs.md` — stub
+     - `milestone.yaml` — written now with this schema:
+       ```yaml
+       slug: <ms-slug>
+       forgejoMilestone: <N>
+       forgejoIssue: <issue-#>
+       flag: VEGA_FLAG_MILESTONE_<SLUG_UPPER>
+       dependsOnSpecs: []
+       status: planned
+       ```
+   - `<SLUG_UPPER>` converts hyphens in `<ms-slug>` to underscores and uppercases (e.g., `eval-harness` -> `EVAL_HARNESS`)
+   - Commit: `git add docs/milestones/M<N>-<ms-slug>/ && git commit -m "docs(milestone): scaffold M<N>-<ms-slug> directory"`
+   - Push: `git push -u origin milestone/<ms-slug>`
+
+7. **Update or create the stories issue**
+   - The issue title MUST be `Milestone: <ms-slug>` (drop any `(M#)` or `— consolidated user stories` suffix)
    - Build the issue body with two sections:
      1. If a press release preceded this milestone, embed its full text under a `## Press Release` heading at the top of the issue body. This is the working-backwards doc that scoped the milestone — reviewers must be able to read it directly on the issue. Do NOT link to vault file paths (private, invisible to reviewers).
      2. Below the press release (or at the top if no press release), include all refined stories from `refined_stories.md` under a `## User Stories` heading.
    - If `issue_number` is provided:
-     - GitHub: `gh issue edit <number> --repo owner/repo --body "BODY"`
-     - Update the issue title to "[Milestone Title]: User Stories for Review"
-     - Add the `product` label to the issue
+     - GitHub: `gh issue edit <number> --repo owner/repo --title "Milestone: <ms-slug>" --body "BODY"`
+     - Add the `kind:milestone` and `product` labels to the issue
      - Set the milestone on the issue
      - Assign to the business agent's account
    - If `issue_number` is blank:
-     - Title: "[Milestone Title]: User Stories for Review"
-     - GitHub: `gh issue create --repo owner/repo --title "TITLE" --body "BODY" --label "product" --milestone "MILESTONE"`
+     - GitHub: `gh issue create --repo owner/repo --title "Milestone: <ms-slug>" --body "BODY" --label "kind:milestone" --label "product" --milestone "Milestone: <ms-slug>"`
      - Assign to the business agent's account
+   - Record the resulting issue number — it goes into `forgejoIssue` in `milestone.yaml` (re-edit and commit the yaml if the issue was newly created in this step)
 
-6. **Verify the setup**
+8. **Verify the setup**
    - Confirm the milestone exists and the issue is linked to it
-   - Confirm labels are applied
+   - Confirm `kind:milestone` and `product` labels are applied
+   - Confirm the `milestone/<ms-slug>` branch exists on origin and `docs/milestones/M<N>-<ms-slug>/milestone.yaml` is committed
    - Record all URLs and numbers
 
 ## Output Format
@@ -67,26 +106,36 @@ A summary of everything that was created or updated.
 
 ## Milestone
 
-- **Title**: [milestone title]
-- **Number**: [milestone number]
+- **Slug**: [ms-slug]
+- **Title**: Milestone: [ms-slug]
+- **Number**: [milestone number — this is the M<N> in the docs dir]
 - **URL**: [milestone URL]
 - **Status**: [created | already existed]
+
+## Repo Scaffold
+
+- **Branch**: milestone/[ms-slug] — [created | already existed]
+- **Docs directory**: docs/milestones/M[N]-[ms-slug]/
+- **Files**: press-release.md (stub), internal-faq.md (stub), designs.md (stub), milestone.yaml
+- **Feature flag**: VEGA_FLAG_MILESTONE_[SLUG_UPPER]
 
 ## Issue
 
 - **Number**: [issue number]
-- **Title**: [issue title]
+- **Title**: Milestone: [ms-slug]
 - **URL**: [issue URL]
 - **Status**: [updated | created]
-- **Labels**: [comma-separated labels applied]
+- **Labels**: kind:milestone, product, [others]
 - **Assigned To**: [agent username]
 
 ## Actions Taken
 
-1. [Description of each action, e.g., "Created milestone 'Homelab Monitoring Stack'"]
-2. [e.g., "Updated issue #42 body with 4 refined user stories"]
-3. [e.g., "Added user-story label to issue #42"]
-4. [e.g., "Linked issue #42 to milestone #3"]
+1. [Description of each action, e.g., "Created milestone 'Milestone: eval-harness'"]
+2. [e.g., "Created branch milestone/eval-harness off origin/main"]
+3. [e.g., "Scaffolded docs/milestones/M5-eval-harness/ with milestone.yaml"]
+4. [e.g., "Retitled issue #42 to 'Milestone: eval-harness'"]
+5. [e.g., "Added kind:milestone label to issue #42"]
+6. [e.g., "Linked issue #42 to milestone"]
 
 ## Platform
 
@@ -101,28 +150,39 @@ A summary of everything that was created or updated.
 
 ## Milestone
 
-- **Title**: Homelab Monitoring Stack
+- **Slug**: homelab-monitoring-stack
+- **Title**: Milestone: homelab-monitoring-stack
 - **Number**: 3
 - **URL**: https://github.com/ncrmro/homelab/milestone/3
 - **Status**: created
 
+## Repo Scaffold
+
+- **Branch**: milestone/homelab-monitoring-stack — created
+- **Docs directory**: docs/milestones/M3-homelab-monitoring-stack/
+- **Files**: press-release.md (stub), internal-faq.md (stub), designs.md (stub), milestone.yaml
+- **Feature flag**: VEGA_FLAG_MILESTONE_HOMELAB_MONITORING_STACK
+
 ## Issue
 
 - **Number**: 42
-- **Title**: Homelab Monitoring Stack: User Stories for Review
+- **Title**: Milestone: homelab-monitoring-stack
 - **URL**: https://github.com/ncrmro/homelab/issues/42
 - **Status**: updated
-- **Labels**: product, enhancement
+- **Labels**: kind:milestone, product
 - **Assigned To**: luce-ncrmro
 
 ## Actions Taken
 
-1. Created milestone "Homelab Monitoring Stack" (#3)
-2. Created labels: product, engineering
-3. Updated issue #42 body with 4 refined user stories
-4. Added user-story label to issue #42
-5. Set milestone on issue #42 to "Homelab Monitoring Stack"
-6. Assigned issue #42 to luce-ncrmro
+1. Created milestone "Milestone: homelab-monitoring-stack" (#3)
+2. Created labels: kind:milestone, kind:spec, kind:spike, product, engineering
+3. Created branch milestone/homelab-monitoring-stack off origin/main
+4. Scaffolded docs/milestones/M3-homelab-monitoring-stack/ with milestone.yaml (deps: [])
+5. Updated issue #42 body with 4 refined user stories
+6. Retitled issue #42 to "Milestone: homelab-monitoring-stack"
+7. Added kind:milestone and product labels to issue #42
+8. Set milestone on issue #42 to "Milestone: homelab-monitoring-stack"
+9. Assigned issue #42 to luce-ncrmro
 
 ## Platform
 
@@ -132,19 +192,21 @@ A summary of everything that was created or updated.
 
 ## Quality Criteria
 
-- A milestone was found or created and its title and URL are recorded
-- The issue is associated with the milestone
-- The issue body was updated with the refined user stories in standard format
-- The `product` label is on the issue
-- The report includes milestone title, issue number, and URLs
-- The `product` and `engineering` labels exist on the repo for future use
+- A milestone was found or created with title `Milestone: <ms-slug>` and its URL is recorded
+- The `milestone/<ms-slug>` branch exists on origin (created off main, or skipped because it already existed)
+- `docs/milestones/M<N>-<ms-slug>/` exists with `press-release.md`, `internal-faq.md`, `designs.md`, and a populated `milestone.yaml` (schema fields: slug, forgejoMilestone, forgejoIssue, flag, dependsOnSpecs, status)
+- The stories issue is titled `Milestone: <ms-slug>` (no `(M#) — consolidated user stories` suffix)
+- The issue body contains the refined user stories
+- The `kind:milestone` and `product` labels are on the issue
+- The report includes milestone title, issue number, branch name, docs directory, and URLs
+- The `kind:milestone`, `kind:spec`, `kind:spike`, `product`, and `engineering` labels exist on the repo for future use
 
 ## Next Steps
 
 After this workflow completes, suggest the following to the user:
 
-> The milestone and user stories are ready. The natural next step is to run **`project/milestone_engineering_handoff`** to produce an internal FAQ, conduct the document review, create functional requirement specs, and create a single plan issue tracking all implementation work.
+> The milestone, branch, and docs scaffold are ready. The natural next step is to run **`project/milestone_engineering_handoff`** to produce an internal FAQ, conduct the document review, create one or more `spec/<spec-slug>` branches with functional requirement specs, and create a single plan issue tracking all implementation work.
 
 ## Context
 
-This is the final step that makes everything concrete on the platform. After this step, a human can review the consolidated issue, comment on individual stories, and approve them before agents begin work. The milestone provides the tracking container, and the issue serves as the parent scope document.
+This is the step that makes the milestone concrete on the platform AND in the repo. After this step, a human can review the consolidated `Milestone:` issue, comment on individual stories, and approve them before agents begin spec work. The milestone provides the tracking container; the issue is the parent scope document; the `milestone/<ms-slug>` branch and `docs/milestones/M<N>-<ms-slug>/` directory are where the long-lived product docs (press release, internal FAQ, designs) and the `milestone.yaml` dependency declaration live. Specs are peer artifacts created downstream in `create_specs`.

--- a/deepwork/jobs/project/steps/write_internal_faq.md
+++ b/deepwork/jobs/project/steps/write_internal_faq.md
@@ -67,14 +67,26 @@ Read the scope analysis from the previous step and the press release embedded in
    - `yellow`: some stories have unresolved questions — spikes required before specs can be written
    - `red`: one or more stories are infeasible or require scope renegotiation before proceeding
 
-6. **Post the internal FAQ as a comment**
-   - Post the internal FAQ as a comment on the milestone issue (visible to all stakeholders)
+6. **Publish the internal FAQ to the milestone directory**
+
+   Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md`), the canonical in-repo home for a milestone's internal FAQ is `docs/milestones/M<N>-<ms-slug>/internal-faq.md` on the `milestone/<ms-slug>` branch.
+
+   - Derive `<ms-slug>` and the Forgejo milestone id `<N>` from the milestone issue's milestone metadata (or the prior `setup_milestone` artifacts)
+   - Check out `milestone/<ms-slug>` (or work in its worktree)
+   - Write the full internal FAQ to `docs/milestones/M<N>-<ms-slug>/internal-faq.md`, replacing the stub created by `setup_milestone`
+   - Commit: `git commit -m "docs(milestone): publish internal FAQ for <ms-slug>"`
+   - Push: `git push origin milestone/<ms-slug>`
+
+7. **Post the internal FAQ as a comment**
+   - Post the internal FAQ as a comment on the milestone issue (visible to all stakeholders); the comment body MAY link back to the canonical `docs/milestones/M<N>-<ms-slug>/internal-faq.md` written in step 6
    - GitHub: `gh issue comment {number} --repo {owner}/{repo} --body "$BODY"`
    - Forgejo: `fj issue comment {number} -r {owner}/{repo} --body "$BODY"`
 
 ## Output Format
 
-### internal_faq.md
+### docs/milestones/M<N>-<ms-slug>/internal-faq.md
+
+The canonical in-repo home for the internal FAQ. Written to the `milestone/<ms-slug>` branch by step 6. The DeepWork artifact tracked as `internal_faq` is this file (or a copy of its content under `.deepwork/tmp/` for handoff purposes).
 
 ```markdown
 # Internal FAQ: [Milestone Title]
@@ -158,6 +170,7 @@ validate whether pg_trgm is sufficient or if Elasticsearch is required — this 
 - T-shirt sizing is concrete (not "TBD") with a written justification for each story
 - Required spikes are listed with a clear blocking question (not just "needs investigation")
 - Summary verdict is one of `green`, `yellow`, or `red` with supporting rationale
+- The internal FAQ is committed to `docs/milestones/M<N>-<ms-slug>/internal-faq.md` on the `milestone/<ms-slug>` branch and pushed before the step completes
 - Internal FAQ is posted as a comment on the milestone issue before the step completes
 
 ## Context

--- a/deepwork/jobs/project/steps/write_press_release.md
+++ b/deepwork/jobs/project/steps/write_press_release.md
@@ -100,8 +100,20 @@ Read the context brief from the previous step and the conventions at `.agents/co
     - Label the issue with `press-release` (create the label if it doesn't exist)
     - Record the **full URL** of the created issue in `.deepwork/tmp/<slug>-press-release-issue-url.md`
     - Update the zk note's `issue_ref` frontmatter field with the created issue URL
-    - If the project repo already stores press releases as tracked content, publish the finalized draft there as a separate explicit step after the issue is created
-    - If the project does not store press releases in-repo, keep `.deepwork/tmp/press_release.mdx` as the transient local artifact and treat the issue as the canonical published record
+
+13. **Publish the canonical in-repo copy to the milestone directory**
+
+    Per the milestone/spec convention (see `docs/conventions/milestones-and-specs.md`), the canonical in-repo home for a milestone's press release is `docs/milestones/M<N>-<ms-slug>/press-release.md` on the `milestone/<ms-slug>` branch.
+
+    - If a milestone for this press release already exists (the user can supply `<ms-slug>` and the Forgejo milestone id `<N>`, or you can derive them from prior `setup_milestone` artifacts):
+      - Check out the `milestone/<ms-slug>` branch (or work in its worktree)
+      - Write the audience-facing press release content to `docs/milestones/M<N>-<ms-slug>/press-release.md`, replacing the stub created by `setup_milestone`
+      - Commit: `git commit -m "docs(milestone): publish press release for <ms-slug>"`
+      - Push: `git push origin milestone/<ms-slug>`
+    - If no milestone exists yet (the press release is running ahead of `setup_milestone`, which is normal — the press release URL feeds milestone setup):
+      - Keep `.deepwork/tmp/<slug>-press-release.mdx` as the transient handoff artifact
+      - Treat the published issue as the canonical record until `setup_milestone` runs
+      - `setup_milestone` will create the milestone dir with a press-release.md stub; either re-run this step with `<ms-slug>` + `<N>` supplied, or copy the press release content into `docs/milestones/M<N>-<ms-slug>/press-release.md` manually on the `milestone/<ms-slug>` branch as a separate explicit step
 
 ## Output Format
 
@@ -110,9 +122,9 @@ Read the context brief from the previous step and the conventions at `.agents/co
 The finished press release in MDX format. Write the local workflow artifact to a
 unique path under `.deepwork/tmp/`, such as `.deepwork/tmp/keystone-project-agent-press-release.mdx`.
 
-If the project already stores press releases in-repo, publish the finalized draft
-to the project's designated directory, typically `posts/press_releases/`, as a
-separate explicit publication step.
+When a milestone exists, also publish the finalized press release as
+`docs/milestones/M<N>-<ms-slug>/press-release.md` on the `milestone/<ms-slug>` branch
+(see step 13). This is the canonical in-repo home per the milestone/spec convention.
 
 ### zk note in the configured notes dir
 
@@ -219,6 +231,7 @@ The issue body has five parts, in order:
 - The issue title follows the `Press Release: <Product Label>` format
 - The issue body has a human-readable context header above the first `---` — no jargon or internal tool names
 - The press release blockquote is enclosed between two `---` separators
+- When a milestone is known (`<ms-slug>` + `<N>` supplied or derivable), the press release content has been written to `docs/milestones/M<N>-<ms-slug>/press-release.md` on the `milestone/<ms-slug>` branch and pushed
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Updates the deepwork `project` job's step instructions so future engineering-handoff runs produce artifacts that match the milestone/spec/spike convention adopted in ncrmro/vega (`docs/conventions/milestones-and-specs.md`). Edits are limited to `deepwork/jobs/project/` — the job's step inventory and ordering are unchanged.

Five behavior changes, one commit each:

- `setup_milestone`: also creates `milestone/<ms-slug>` off `main` and scaffolds `docs/milestones/M<N>-<ms-slug>/` (press-release.md, internal-faq.md, designs.md, milestone.yaml with the documented schema); retitles the stories issue to `Milestone: <ms-slug>` and applies `kind:milestone`. Notes `spike/<slug>` as the third branch type per the convention.
- `create_specs`: branch is now `spec/<spec-slug>` off `main` (peers with milestone branches, not children); spec slug is prompted/inferred for the engineering scope (not auto-derived from the milestone slug); files land in `docs/specs/NNN-<spec-slug>/`.
- `create_plan_issue`: retitles to `Spec: <spec-slug>` with `kind:spec` label, adds a "Used by milestones" reverse-lookup section, and appends `<spec-slug>` to the parent milestone's `milestone.yaml.dependsOnSpecs` (when a parent milestone exists). Phased task checklist unchanged.
- `write_press_release`: redirects the canonical in-repo output to `docs/milestones/M<N>-<ms-slug>/press-release.md` on the `milestone/<ms-slug>` branch.
- `write_internal_faq`: redirects the canonical in-repo output to `docs/milestones/M<N>-<ms-slug>/internal-faq.md` on the `milestone/<ms-slug>` branch. The milestone-issue comment is still posted.

Each edit applies to both `steps/<name>.md` and the inline `instructions:` block in `job.yml`, matching prior precedent (see AGENTS.md learning history). Existing review/quality gates in `job.yml` are preserved.

## Test plan

- [ ] Run `project/milestone` (or the full `press_release` → `milestone` chain) against a sandbox repo and confirm `milestone/<ms-slug>` branch, `docs/milestones/M<N>-<ms-slug>/` directory, and `milestone.yaml` are created with the documented schema, and the issue is titled `Milestone: <ms-slug>` with `kind:milestone`.
- [ ] Run `project/milestone_engineering_handoff` against a sandbox milestone; confirm spec branch is `spec/<spec-slug>` off main, specs land under `docs/specs/NNN-<spec-slug>/`, the resulting issue is titled `Spec: <spec-slug>` with `kind:spec`, and the parent milestone's `milestone.yaml.dependsOnSpecs` was appended.
- [ ] Confirm `write_press_release` writes the canonical copy to `docs/milestones/M<N>-<ms-slug>/press-release.md` when a milestone slug is supplied.
- [ ] Confirm `write_internal_faq` writes to `docs/milestones/M<N>-<ms-slug>/internal-faq.md` and still posts the comment on the milestone issue.