### PR TITLE
feat(stalwart): enable CalDAV and CardDAV alongside JMAP

### DIFF
--- a/hosts/ocean/nginx.nix
+++ b/hosts/ocean/nginx.nix
@@ -194,7 +194,15 @@ in
     };
   };
 
-  # Stalwart Mail Admin - Tailscale only
+  # Stalwart Mail - Tailscale only
+  # Single HTTP listener on :8082 serves the admin web UI, the REST
+  # management API, JMAP, CalDAV (/dav/cal), CardDAV (/dav/card), WebDAV
+  # (/dav/file), and the DAV bootstrap endpoints (/.well-known/{caldav,carddav}).
+  # The catch-all "/" location already proxies every path to upstream; the
+  # explicit /dav/ and /.well-known/* blocks below exist so an operator
+  # auditing the vhost can see at a glance which DAV surface is exposed
+  # and so DAV-specific tweaks (e.g. larger client_max_body_size for big
+  # vCard imports) have an obvious home.
   services.nginx.virtualHosts."mail.ncrmro.com" = {
     forceSSL = true;
     useACMEHost = "wildcard-ncrmro-com";
@@ -202,6 +210,23 @@ in
     locations."/" = {
       proxyPass = "http://127.0.0.1:8082";
       proxyWebsockets = true;
+    };
+    # CalDAV bootstrap — clients hit this first for principal discovery.
+    locations."/.well-known/caldav" = {
+      proxyPass = "http://127.0.0.1:8082";
+    };
+    # CardDAV bootstrap — same role for address books.
+    locations."/.well-known/carddav" = {
+      proxyPass = "http://127.0.0.1:8082";
+    };
+    # All DAV collections live under /dav/{cal,card,file,pal,itip}/.
+    # Raise body size so calendar/address-book imports (full ICS/VCF
+    # dumps from existing clients) aren't truncated by nginx's 1m default.
+    locations."/dav/" = {
+      proxyPass = "http://127.0.0.1:8082";
+      extraConfig = ''
+        client_max_body_size 50M;
+      '';
     };
   };
 }


### PR DESCRIPTION
## Summary

- Enables CalDAV and CardDAV on the Stalwart HTTP listener whenever `services.stalwart-mail` is enabled — they ride on the same `protocol = "http"` listener as JMAP and the admin UI, routed by URL path. No separate enable knob exists in Stalwart 0.15.5, so the policy "stalwart-mail enabled implies DAV enabled" needs no extra toggle.
- Exposes the DAV endpoints via nginx on the existing `mail.ncrmro.com` vhost (extended, not new vhost) with explicit `/.well-known/caldav`, `/.well-known/carddav`, and `/dav/` location blocks. Tailscale-only via the existing `extraConfig = tailscaleOnly`.
- No firewall changes — DAV stays bound to `127.0.0.1:8082` and reaches clients only through nginx, which is already firewalled and TLS-fronted.
- No agenix burner account in this PR — that is a follow-up provisioning step.

## Why

The Vega `spec/stalwart-integration` branch needs a real CalDAV + CardDAV endpoint to wire its tsdav-based providers against. Today the only externally-visible Stalwart surface on `mail.ncrmro.com` is documented as "admin UI" — the path-routing reality is that DAV was already reachable through the catch-all `/` proxy, but it was not auditable from the vhost and had no DAV-specific tuning (body size, etc.).

## Stalwart config research

- Pinned version: **0.15.5** (`pkgs.stalwart-mail.version`).
- DAV enable mechanism: **none required.** Stalwart 0.15.5's `ServerProtocol` enum (`crates/common/src/config/server/mod.rs`) only supports `smtp / lmtp / imap / pop3 / http / managesieve`. Any `protocol = "http"` listener serves JMAP + admin UI + REST API + CalDAV (`/dav/cal/`) + CardDAV (`/dav/card/`) + WebDAV (`/dav/file/`) + principal discovery (`/dav/pal/`) + scheduling (`/dav/itip/`) + the well-known bootstrap (`/.well-known/caldav`, `/.well-known/carddav`). Path constants verified in `crates/groupware/src/lib.rs` (`DavResourceName::base_path`).
- The new `sharing.*` and `dav.collection.assisted-discovery` knobs added to the optional module are not "enable DAV" — they widen the *sharing* surface so principals can discover and share each other's collections, which the Vega agent/human scenario needs. They mirror what `keystone/modules/os/mail.nix` already sets on ocean.
- Sources: Stalwart 0.15.5 source tree on GitHub — `resources/config/config.toml`, `crates/common/src/config/server/mod.rs` (ServerProtocol enum), `crates/groupware/src/lib.rs` (DavResourceName base_path/collection_path), `tests/src/webdav/basic.rs` (well-known PROPFIND behavior).
- Vhost choice: **extend `mail.ncrmro.com`** rather than introduce `dav.ncrmro.com`. Stalwart's DAV surface is bounded under a single `/dav/` prefix plus the two `.well-known` paths, so path-routing stays small and obvious. A separate vhost would have duplicated the ACME cert, Tailscale ACL, and upstream wiring for no operational gain.

## Notes for the human reviewer

- The `hosts/common/optional/stalwart-mail.nix` file is the policy/template surface — the **active** Stalwart config on ocean comes from `keystone/modules/os/mail.nix` (upstream keystone flake), auto-enabled by `keystone.services.mail.host = "ocean"`. That upstream module already binds the HTTP listener to `127.0.0.1:8082` (not :8080) because k8s ingress uses :8080. The nginx changes here reflect the live `:8082` port.
- A `nix flake check` from this branch surfaces two pre-existing errors (`vm-image-mercury` missing disko config, top-level `adminEmail` missing `email` attribute) and an `evaluation warning: services.stalwart-mail has been renamed to services.stalwart` — none related to this change. `nix build .#nixosConfigurations.ocean.config.system.build.toplevel` succeeds.
- Stalwart's own config validation runs at activation, not eval; a green `nix build` does not prove Stalwart will accept the live config — it only proves the Nix module typechecks. The `sharing` block matches what the keystone module already ships and runs on ocean today.

## Test plan

- [x] `nix build .#nixosConfigurations.ocean.config.system.build.toplevel` succeeds
- [x] `nix flake check` — only pre-existing unrelated errors (vm-image-mercury disko, adminEmail attribute)
- [ ] (Post-merge, human) `nixos-rebuild switch --flake .#ocean`
- [ ] (Post-deploy) `curl -u <user>:<pw> https://mail.ncrmro.com/.well-known/caldav -X PROPFIND -H 'Depth: 0' -H 'Content-Type: application/xml' -d '<?xml version="1.0"?><propfind xmlns="DAV:"><prop><resourcetype/></prop></propfind>'` from a Tailscale client returns a 207 multistatus
- [ ] (Post-deploy) Same for `/.well-known/carddav`
- [ ] (Post-deploy) `tsdav.createDAVClient` discovery against `https://mail.ncrmro.com/` surfaces at least one calendar and one address book for the test user

## Out of scope

- The `vega-dev@ncrmro.com` burner account and its agenix secret (separate follow-up).
- Touching the Vega repo or its tsdav wiring.
- Enabling Stalwart's WebDAV file-share surface beyond what ships on the same listener.
- Modifying Stalwart's directory/auth backend.

## Follow-ups an operator may want later

- DAV-specific quota knobs (vCard/iCal collection size caps) — Stalwart exposes these but defaults are fine for now.
- Sync-token TTL tuning if clients churn `/dav/cal/*/.sync-token` polls.
- Explicit default-ACL per principal namespace if/when more humans join the fleet — the keystone module already wires per-agent ACLs but does not template per-human defaults.