### PR TITLE
docs(agents): add Astro and Cloudflare Worker skills

### DIFF
--- a/agents/bridl/profiles/platform-engineer/profile.yml
+++ b/agents/bridl/profiles/platform-engineer/profile.yml
@@ -1,3 +1,6 @@
 id: platform-engineer
 label: Platform Engineer (role base)
-controls: {}
+controls:
+  skills:
+    - /Users/nicholas/repos/ncrmro/ks-config/agents/skills/platform-web
+    - /Users/nicholas/repos/ncrmro/ks-config/agents/skills/platform-ci-cd

--- a/agents/bridl/profiles/product-lead/profile.yml
+++ b/agents/bridl/profiles/product-lead/profile.yml
@@ -1,3 +1,6 @@
 id: product-lead
 label: Product Lead (role base)
-controls: {}
+controls:
+  skills:
+    - /Users/nicholas/repos/ncrmro/ks-config/agents/skills/platform-web
+    - /Users/nicholas/repos/ncrmro/ks-config/agents/skills/platform-ci-cd

--- a/agents/skills/platform-ci-cd/SKILL.md
+++ b/agents/skills/platform-ci-cd/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: platform-ci-cd
+description: "Platform CI/CD and deployment architecture — provider-agnostic pipelines, previews, secrets, releases, and hosting deploys"
+---
+
+Use this skill when planning, implementing, or reviewing build, preview, deploy,
+and release automation across providers.
+
+Keep this skill provider/implementation agnostic. Provider-specific deployment
+notes belong in sibling files and are referenced from this skill.
+
+## Supporting references
+
+Read the relevant files before changing deployment automation:
+
+- [Cloudflare Workers deployment notes](cloudflare-workers.md) — Wrangler,
+  Workers vs Pages, local preview, bindings, Workers Builds, GitHub Actions,
+  secrets, and PR checks.
+
+## Decision areas
+
+Use this skill for:
+
+- CI workflow structure and required checks.
+- Preview deployment strategy and branch/environment isolation.
+- Production deploy promotion, approvals, and rollback shape.
+- Secret management and build-time vs runtime environment variables.
+- Provider-hosted builds vs GitHub Actions or other external CI.
+- Deployment validation: smoke tests, migrations, asset uploads, and generated
+  types.
+- Monorepo deploy paths, watch paths, and working-directory discipline.
+
+## Grouping convention
+
+- Add provider/deploy-target files here: `cloudflare-workers.md`, `vercel.md`,
+  `fly-io.md`, `railway.md`, etc.
+- Add generic process files here when they span providers: `preview-envs.md`,
+  `release-gates.md`, `secrets.md`, etc.
+- Keep framework runtime decisions in `platform-web` and database/storage
+  decisions in their own platform skills; link between skills rather than
+  duplicating content.

--- a/agents/skills/platform-ci-cd/cloudflare-workers.md
+++ b/agents/skills/platform-ci-cd/cloudflare-workers.md
@@ -1,0 +1,228 @@
+# Cloudflare Workers deployment notes
+
+Use this skill when planning, implementing, or reviewing Cloudflare Workers
+hosting for Astro or custom frontend/server runtimes.
+
+## Choose the Worker shape
+
+### Astro Cloudflare adapter Worker
+
+Use when Astro owns server rendering or runtime endpoints.
+
+Typical config:
+
+```jsonc
+{
+  "name": "app-name",
+  "main": "@astrojs/cloudflare/entrypoints/server",
+  "compatibility_date": "2026-05-13",
+  "compatibility_flags": ["global_fetch_strictly_public"],
+  "assets": { "directory": "./dist", "binding": "ASSETS" },
+  "observability": { "enabled": true }
+}
+```
+
+Add `nodejs_compat` only when dependencies require Node compatibility
+(Auth.js, some DB clients, Stripe, Astro runtime edges). If enabled, test dynamic
+SSR routes under workerd/Cloudflare preview; some Astro/workerd combinations can
+mis-handle Node-like `process` detection.
+
+### Astro hybrid/static build plus generated Worker
+
+Use when current pages are static but a Worker entrypoint is desired for future
+endpoints. Astro may emit `dist/_worker.js/index.js` depending on adapter
+version/config. Keep Wrangler `main` aligned with the actual build output.
+
+### Hand-written Worker in front of static assets
+
+Use when Astro is only a static bundler and the Worker owns auth, R2, routing,
+or SPA fallback.
+
+```jsonc
+{
+  "main": "src/worker.ts",
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  }
+}
+```
+
+- `run_worker_first: true` is required if auth or logging must cover every
+  asset request, not just navigations.
+- The Worker should call `env.ASSETS.fetch(request)` after any gates/special
+  routes.
+- Keep public immutable blobs on content-addressed URLs and set long cache
+  headers.
+
+### Cloudflare Pages style
+
+Use only for projects intentionally deploying with Pages commands:
+
+- `wrangler pages dev ./dist`
+- `wrangler pages deploy ./dist`
+- `pages_build_output_dir = "./dist"` in `wrangler.toml`
+
+Do not mix Pages assumptions into Workers deployments without a deliberate
+migration plan.
+
+## Wrangler config checklist
+
+Core fields:
+
+- `name`: stable Worker name.
+- `main`: adapter entrypoint or custom Worker source.
+- `compatibility_date`: pin and update deliberately.
+- `compatibility_flags`: start minimal; add `nodejs_compat` only when needed.
+- `assets`: `directory`, `binding`, optional SPA fallback/run-worker-first.
+- `observability.enabled`: enable unless there is a reason not to.
+- `routes` / `custom_domain` / `workers_dev` / `preview_urls`: choose per
+  production and preview needs.
+
+Bindings:
+
+- `vars`: non-secret runtime values only.
+- Secrets: set with `wrangler secret put NAME` or CI secret injection; never
+  commit tokens/private keys.
+- `kv_namespaces`: bind `SESSION` when Astro sessions or adapter provisioning
+  need a stable namespace.
+- `r2_buckets`: uploads, static blobs, firmware, demo bundles.
+- `send_email`: contact forms/transactional email where Cloudflare Email
+  Routing send bindings are used.
+- DB/API services: Turso/libSQL URLs may be non-secret, but auth tokens are
+  secrets.
+
+Build-time vs runtime env:
+
+- Vite/Astro inlines public client vars at build time (`PUBLIC_*`, legacy
+  `NEXT_PUBLIC_*`). Setting them only in Wrangler `vars` gives server runtime
+  access but does not populate client bundles.
+- CI/deploy systems must export public build vars before `astro build`.
+
+## Local development and preview
+
+- `astro dev`: fastest feedback for Astro pages; use adapter
+  `platformProxy: { enabled: true }` if code accesses Cloudflare bindings.
+- `astro preview`: validates Astro build output, but may not exactly reproduce
+  workerd/binding behavior.
+- `wrangler dev`: use for custom Workers and binding/asset routing validation.
+- `wrangler dev --ip 0.0.0.0`: expose preview to LAN/tailnet devices when
+  needed.
+- `wrangler pages dev ./dist`: Pages-only local preview.
+
+Always test the path that matters:
+
+- Auth callback/session routes.
+- API endpoints with bindings.
+- Asset fallback/client-side routes.
+- R2 blob streaming and cache headers.
+- Dynamic SSR pages under Cloudflare/workerd, especially with `nodejs_compat`.
+
+## Deployment options
+
+### Manual/local deploy
+
+Use for first deploys, smoke tests, or emergency pushes:
+
+```bash
+bun install
+bun run build
+bunx wrangler deploy
+```
+
+For monorepos, run from the app directory or pass the appropriate Wrangler
+config/working directory. Generate binding types when available:
+
+```bash
+bunx wrangler types
+# or project-specific env interface output
+bunx wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts
+```
+
+### Cloudflare Workers Builds
+
+Use when Cloudflare owns branch/PR preview builds.
+
+- Configure root directory / build command / deploy command in Cloudflare.
+- In monorepos, set watch paths carefully. If only `code/web/**` is watched,
+  docs/content outside that path may not trigger previews.
+- Know whether previews share production bindings/databases. If they do, note
+  the risk in PRs and avoid destructive preview actions.
+- If a branch adds DB migrations, run compatible migrations before validating
+  preview pages that select new columns.
+
+### GitHub Actions deploy
+
+Use when GitHub should own CI, tests, migrations, and production deploy order.
+
+Minimum shape:
+
+```yaml
+name: deploy-web
+on:
+  push:
+    branches: [main]
+    paths:
+      - code/web/**
+      - .github/workflows/deploy-web.yml
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: code/web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+        env:
+          PUBLIC_SITE_URL: https://example.com
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: code/web
+          command: deploy
+```
+
+Recommended additions:
+
+- Typecheck/test before deploy.
+- Run migrations before deploy when new code expects new schema.
+- Upload R2/static blobs before deploy if manifest points at them.
+- Use GitHub Environments for production approval/secrets.
+- Separate preview deploy workflows from production deploy workflows.
+
+## Auth and secrets on Workers
+
+Auth.js/Google common secrets:
+
+- `AUTH_SECRET`
+- `AUTH_GOOGLE_ID`
+- `AUTH_GOOGLE_SECRET`
+- optional `AUTH_REDIRECT_PROXY_URL` for stable callbacks from preview URLs
+- optional `AUTH_URL` depending on routing/library assumptions
+
+Operational rules:
+
+- Production must fail closed if required auth secrets are missing.
+- Local dev may disable auth or use a clearly marked dev-only credentials
+  provider, but never let dev credentials leak into SaaS mode.
+- Restrict sign-in by email/domain in callbacks for admin/private products.
+- If protecting static assets, enforce it in the Worker before `ASSETS.fetch`,
+  not only inside the client app.
+
+## PR/review checklist
+
+- Does Wrangler `main` match the chosen Worker shape and generated output?
+- Are secrets absent from `wrangler.jsonc`/`wrangler.toml`?
+- Are build-time public vars supplied by CI/Workers Builds?
+- Are preview deployments documented, including shared DB/binding tradeoffs?
+- Are local preview commands documented for `astro dev`, `wrangler dev`, or
+  Pages as appropriate?
+- Are R2/KV/email bindings named consistently with code and generated types?
+- Is `nodejs_compat` justified and smoke-tested on dynamic routes?

--- a/agents/skills/platform-web/SKILL.md
+++ b/agents/skills/platform-web/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: platform-web
+description: "Platform web architecture — framework/runtime selection, rendering modes, static assets, and web auth boundaries"
+---
+
+Use this skill when planning, implementing, or reviewing web application
+architecture across frameworks and hosting providers.
+
+Keep this skill provider/implementation agnostic. Put framework- or provider-
+specific notes in sibling files and reference them here rather than creating a
+new top-level skill for every tool.
+
+## Supporting references
+
+Read the relevant files before making design or implementation decisions:
+
+- [Astro implementation notes](astro.md) — Astro static, SPA, hybrid, SSR,
+  local Node/Bun, Cloudflare adapter, and Auth.js patterns observed across
+  local repos.
+- [Static assets and SPA delivery](static-assets.md) — immutable assets,
+  SPA fallback, cache boundaries, build-time env, and asset auth gates.
+
+## Decision areas
+
+Use this skill for:
+
+- Web framework/runtime selection.
+- Static vs SPA vs hybrid vs SSR rendering decisions.
+- Adapter/runtime selection: Node/Bun, edge workers, static hosts, or custom
+  serving shells.
+- Client-side build environment and public variable handling.
+- Static asset delivery, cache policy, SPA fallback, and protected assets.
+- Web auth boundary placement: client-only hints vs server/edge enforcement.
+- Porting web apps across frameworks or hosting runtimes.
+
+## Grouping convention
+
+- Add framework-specific files here: `astro.md`, `nextjs.md`, `remix.md`, etc.
+- Add web delivery topic files here: `static-assets.md`, `forms.md`,
+  `web-auth-boundaries.md`, etc.
+- Do not create a top-level `platform-<framework>` skill unless the framework
+  becomes broad enough to own multiple subdocuments.
+- Put deployment pipeline/provider mechanics in `platform-ci-cd`; link back here
+  when a web runtime depends on those mechanics.

--- a/agents/skills/platform-web/astro.md
+++ b/agents/skills/platform-web/astro.md
@@ -1,0 +1,157 @@
+# Astro implementation notes
+
+Use this skill when planning, implementing, or reviewing Astro projects.
+It captures local repo patterns observed across NCRMRO/partner projects and
+turns them into deployment/runtime choices.
+
+## First decision: what is Astro doing?
+
+Pick the smallest runtime that satisfies the product surface.
+
+### 1. Full static site / content app
+
+Use when every route can be built ahead of time and there are no runtime API
+endpoints.
+
+- Astro default output is static; `output: "static"` may be explicit for clarity.
+- No adapter is required unless the host/deploy platform needs one.
+- Local scripts are usually `astro dev`, `astro build`, `astro preview`.
+- Examples:
+  - `ncrmro/catalyst/code/web`: plain static Astro, no adapter.
+  - `scifireality/placeholder/code/web`: static Astro with React/MDX and Vite
+    filesystem allowances for symlinked/generated assets.
+  - `ncrmro/plouton/code/web`: explicit `output: "static"` with React islands.
+
+Use this for marketing/content sites until server endpoints are clearly needed.
+
+### 2. Static SPA with Astro as bundler only
+
+Use when React/client routing owns the app and SSR would only emit an empty
+island shell.
+
+- Set `output: "static"`.
+- Use `client:only` islands for the SPA shell.
+- Serve `index.html` as fallback from the runtime shell.
+- If hosting on Cloudflare, a hand-written Worker can add auth, R2, and SPA
+  fallback without running Astro SSR.
+- Example: `unsupervised/deepwork-frontend/code/web`:
+  - Astro builds one static shell.
+  - Local target is a Bun server with `/api/*`, `/debug/*`, `/ws`.
+  - Hosted target is a thin Cloudflare Worker with `/auth/*`, `/r2/*`, and
+    `env.ASSETS.fetch()`.
+
+Prefer this for CLI/local apps and hosted demo viewers where SSR is pure cost.
+
+### 3. Mostly static site with a few runtime endpoints
+
+Use when pages are mostly static but forms, contact handlers, webhooks, or small
+APIs need runtime execution.
+
+Options:
+
+- Cloudflare adapter with default/static-prerendered pages and individual
+  `export const prerender = false` endpoints.
+- `output: "hybrid"` when the project wants static by default but a server
+  entrypoint available for dynamic routes.
+
+Examples:
+
+- `jtco/marketing-site/code/web`: Cloudflare adapter, contact page/API opt out
+  with `prerender = false`, email binding in Wrangler.
+- `ncrmro/media-production-assistant/code/web`: `output: "hybrid"`; current
+  pages static, Worker entrypoint ready for future endpoints.
+
+Prefer this over full SSR when dynamic behavior is isolated.
+
+### 4. Full SSR on Cloudflare Workers
+
+Use when authenticated dashboards, per-user data, server-rendered pages, or
+runtime APIs are core to the product.
+
+- Set `output: "server"`.
+- Use `@astrojs/cloudflare` adapter.
+- Prerender public/content pages explicitly with `export const prerender = true`.
+- Keep API/auth routes dynamic with `export const prerender = false` where
+  useful for clarity.
+- Use `platformProxy` for local dev when code reads Cloudflare bindings.
+
+Examples:
+
+- `EONMUN/EONMUN/code`: `output: 'server'`; public pages opt into prerender;
+  admin/API/auth routes are dynamic; Auth.js Google admin gate.
+- `ncrmro/plant-caravan/code/web`: `output: 'server'`; docs/blog/team pages
+  prerender; app/API/auth surfaces run on Workers; R2/Turso/Stripe/web-push
+  bindings live in Wrangler.
+
+### 5. Node/Bun SSR or middleware
+
+Use when the app needs local system access, subprocesses, websockets, CAD/tools,
+or to embed Astro inside a larger Node/Bun server.
+
+- Set `output: "server"`.
+- Use `@astrojs/node`.
+- Choose `mode: "standalone"` for a self-contained Node server.
+- Choose `mode: "middleware"` when another server owns routing/lifecycle.
+
+Examples:
+
+- `ncrmro/3dPCB-paper/code/web`: Node standalone; prerendered gallery pages,
+  dynamic local endpoints for open/rebuild/printer actions.
+- `ncrmro/cadeng/code/web-client`: Node middleware embedded by Cadeng's Bun
+  server; stable manifest integration for compiled imports.
+- `ncrmro/vega/code/web`: Node middleware for Keystone/Vega web UI.
+
+## Auth patterns
+
+### Auth.js on Astro/Cloudflare
+
+- Use `@auth/core` directly in Astro API routes or a custom Worker.
+- Mount a catch-all endpoint such as `/api/auth/[...auth].ts` or Worker
+  `/auth/*`.
+- Keep OAuth secrets in Wrangler secrets or CI secrets:
+  - `AUTH_SECRET`
+  - `AUTH_GOOGLE_ID`
+  - `AUTH_GOOGLE_SECRET`
+  - optional `AUTH_REDIRECT_PROXY_URL` for preview URLs/stable callback routing.
+- Use `trustHost: true` on Workers.
+- Prefer JWT sessions unless a DB/session adapter is explicitly required.
+- For admin surfaces, enforce email/domain allowlists in Auth.js callbacks.
+
+Observed repo variants:
+
+- EONMUN: Google OAuth admin allowlist via `ADMIN_EMAILS`; JWT session;
+  `/api/auth`; dynamic admin route.
+- Plant Caravan: Google OAuth in SaaS; credentials provider for local/non-SaaS;
+  local HTTP can use a dev secret and local DB; session callback attaches user id.
+- Unsupervised: hosted Worker has optional Google OAuth, restricted to
+  `@unsupervised.com`; auth is not currently an app-wide gate.
+
+### Static assets behind auth
+
+If the whole SPA/assets must be protected on Cloudflare, do not rely only on
+client-side checks. Put a Worker in front of assets and set Wrangler assets
+`run_worker_first: true`, then call `env.ASSETS.fetch()` after the gate.
+
+## Local dev notes
+
+- `astro dev` is enough for pure Astro and most adapter projects.
+- Use `server.host: "0.0.0.0"` / `allowedHosts: true` when testing across LAN,
+  tailnet, or reverse proxies.
+- Use Cloudflare adapter `platformProxy: { enabled: true }` if local code needs
+  Worker bindings.
+- Use `wrangler dev` for custom Workers or when verifying actual Workers asset
+  routing/bindings.
+- Use `wrangler pages dev ./dist` only for Cloudflare Pages-style projects.
+
+## Review checklist
+
+- Is the selected output mode the smallest viable runtime?
+- Are public pages prerendered when the app is otherwise SSR?
+- Are dynamic endpoints explicitly marked `prerender = false` where ambiguity
+  would hurt future maintainers?
+- Are build-time public env vars supplied during the build, not only in
+  Wrangler runtime `vars`?
+- Does local dev have a safe auth mode, and does production require real
+  secrets?
+- If using `nodejs_compat` with Astro Cloudflare SSR, smoke-test dynamic pages
+  under workerd/preview, not just `astro preview`.

--- a/agents/skills/platform-web/static-assets.md
+++ b/agents/skills/platform-web/static-assets.md
@@ -1,0 +1,47 @@
+# Static assets and SPA delivery
+
+Use the simplest asset delivery model that still enforces the product's access
+and cache requirements.
+
+## Public immutable assets
+
+Use content-addressed or build-hashed filenames for assets that can be cached
+forever.
+
+- Set long-lived immutable cache headers only when the URL changes with content.
+- Keep stable-but-mutable keys on short cache windows.
+- Do not put secrets in client bundles or public asset manifests.
+- Generated manifests should distinguish local filesystem paths from public URLs.
+
+## SPA fallback
+
+For client-routed SPAs, the serving layer should return `index.html` for
+non-asset application routes.
+
+- Static hosts usually expose an SPA fallback setting.
+- Custom servers should try static asset lookup first, then fall back to the
+  shell for navigations.
+- Cloudflare Workers static assets can use
+  `not_found_handling: "single-page-application"`.
+
+## Auth-protected assets
+
+If static assets need auth, enforce it before the asset layer, not only inside
+client code.
+
+- Gate every request path that should be private: HTML, JS, CSS, images, blobs,
+  and client routes.
+- On Cloudflare Workers, `assets.run_worker_first: true` lets a Worker check
+  auth before calling `env.ASSETS.fetch()`.
+- Public content-addressed blobs may intentionally bypass auth; document that
+  decision and validate object keys to prevent traversal or arbitrary reads.
+
+## Build-time public env
+
+Vite/Astro and similar bundlers inline public env at build time. Runtime vars
+from a hosting platform do not automatically appear in already-built client JS.
+
+- Export public client env during CI/build.
+- Keep server-only secrets in runtime secret stores.
+- Use clear naming conventions (`PUBLIC_*`, framework-specific legacy prefixes)
+  and document which side consumes each variable.


### PR DESCRIPTION
## Summary
- add a provider-agnostic `platform-web` skill for web architecture decisions
  - includes `astro.md` for Astro static/SPA/hybrid/SSR/local runtime/auth patterns observed across local repos
  - includes `static-assets.md` for SPA fallback, cache boundaries, build-time env, and protected assets
- add a provider-agnostic `platform-ci-cd` skill for build/deploy/release decisions
  - includes `cloudflare-workers.md` for Wrangler, Workers vs Pages, local preview, bindings, Workers Builds, GitHub Actions, secrets, and PR checks
- attach both platform group skills to the `platform-engineer` and `product-lead` Bridl role profiles so Drago/Luce inherit the reference material

## Validation
- parsed updated profile YAML with `yq`
- parsed new skill frontmatter with `yq`
- verified old top-level implementation/provider skills were removed and grouped docs exist
