### PR TITLE
fix(ocean): enable ncrmro notes sync

### DIFF
--- a/home-manager/ncrmro/ocean.nix
+++ b/home-manager/ncrmro/ocean.nix
@@ -15,6 +15,12 @@
     passwordCommand = "cat /run/agenix/stalwart-mail-ncrmro-password";
   };
 
+  keystone.notes = {
+    enable = true;
+    repo = "ssh://forgejo@git.ncrmro.com:2222/ncrmro/notes.git";
+    daily.enable = true;
+  };
+
   programs.zsh = {
     initContent = ''
       # NixOS rebuild function with --boot support for critical changes


### PR DESCRIPTION
## Summary\n- enable ncrmro Keystone notes sync on ocean\n- keep ocean aligned with workstation/laptop notes repo + daily rollover config\n\n## Verification\n- nix eval .#nixosConfigurations.ocean.config.\"home-manager\".users.ncrmro.keystone.notes.enable => true\n- nix eval .#nixosConfigurations.ocean.config.\"home-manager\".users.ncrmro.systemd.user.services.keystone-notes-sync.Service.Type => oneshot\n- nix build .#nixosConfigurations.ocean.config.\"home-manager\".users.ncrmro.home.activationPackage --no-link\n\n## Operational note\nI also manually restored ocean's current notes checkout to origin/main after saving the divergent local state to a backup branch/stashes, and installed a temporary user notes-sync service so sync works before this config is deployed.