### PR TITLE
feat(notes): make ocean the daily rollover singleton

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1427,8 +1427,8 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1780853045,
-        "narHash": "sha256-9MzzovuLjbSSh44+CvZ1Vv1aLZUGzkAA8koDrSREZWg=",
+        "lastModified": 1780873637,
+        "narHash": "sha256-+ACvP3E7LjgRSLMbkS6pqgn8P7fnBSoovXdUwxBWWoo=",
         "path": "/home/ncrmro/repos/ncrmro/worktrees/keystone/milestone/M10-V2-os-agents",
         "type": "path"
       },

--- a/home-manager/ncrmro/base.nix
+++ b/home-manager/ncrmro/base.nix
@@ -104,7 +104,7 @@
   keystone.notes = {
     enable = true;
     repo = "ssh://forgejo@git.ncrmro.com:2222/ncrmro/notes.git";
-    daily.enable = true;
+    sync.enable = true;
   };
 
   keystone.terminal.aiExtensions.enable = true;

--- a/home-manager/ncrmro/ocean.nix
+++ b/home-manager/ncrmro/ocean.nix
@@ -18,7 +18,7 @@
   keystone.notes = {
     enable = true;
     repo = "ssh://forgejo@git.ncrmro.com:2222/ncrmro/notes.git";
-    daily.enable = true;
+    sync.enable = true;
   };
 
   programs.zsh = {

--- a/modules/keystone/os.nix
+++ b/modules/keystone/os.nix
@@ -31,6 +31,7 @@
     git.host = "ocean";
     immich.host = "ocean";
     immich.workers = [ "ncrmro-workstation" ];
+    notesDaily.host = "ocean";
   };
   keystone.hosts = import ../../hosts.nix;
 


### PR DESCRIPTION
## Summary\n- configure keystone.services.notesDaily.host = ocean\n- keep notes sync/push enabled on all ncrmro hosts\n- stop enabling daily rollover globally so only ocean runs the symlink/journal rollover\n- refresh the keystone path lock for the v2 milestone branch singleton change\n\n## Verification\n- nix eval .#nixosConfigurations.ncrmro-workstation.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => false\n- nix eval .#nixosConfigurations.ncrmro-laptop.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => false\n- nix eval .#nixosConfigurations.ocean.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => true\n- nix build .#nixosConfigurations.ocean.config.\"home-manager\".users.ncrmro.home.activationPackage --no-link