### PR TITLE
fix(flake): refresh keystone path lock without artifacts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1427,8 +1427,8 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1780873637,
-        "narHash": "sha256-+ACvP3E7LjgRSLMbkS6pqgn8P7fnBSoovXdUwxBWWoo=",
+        "lastModified": 1780873990,
+        "narHash": "sha256-A+/Ko6ntP9gwmLYdunpG/1yEZtHqvx9aGqMv/ouUME0=",
         "path": "/home/ncrmro/repos/ncrmro/worktrees/keystone/milestone/M10-V2-os-agents",
         "type": "path"
       },


### PR DESCRIPTION
## Summary\n- refresh keystone path-input lock after removing local ignored build artifacts from the source hash\n- keeps the notesDaily singleton config evaluable on laptop and ocean\n\n## Verification\n- nix hash path /home/ncrmro/repos/ncrmro/worktrees/keystone/milestone/M10-V2-os-agents => sha256-A+/Ko6ntP9gwmLYdunpG/1yEZtHqvx9aGqMv/ouUME0=\n- nix eval .#nixosConfigurations.ncrmro-laptop.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => false\n- nix eval .#nixosConfigurations.ocean.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => true