### PR TITLE
fix(flake): lock plouton from canonical git remote

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1774,14 +1774,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1780626980,
-        "narHash": "sha256-7UPHp69+cDxOJJ6CFixPBWc2khR/IvCsOCAdY4kXpd4=",
-        "path": "/home/ncrmro/repos/ncrmro/plouton",
-        "type": "path"
+        "lastModified": 1780599732,
+        "narHash": "sha256-YHExIkxC1doB770h25cTsulLXeCX8vqJDxB9AhCSPzY=",
+        "ref": "refs/heads/main",
+        "rev": "1e1979c1bf503760de62fb3076245b759c286847",
+        "revCount": 36,
+        "type": "git",
+        "url": "ssh://forgejo@git.ncrmro.com:2222/ncrmro/plouton.git"
       },
       "original": {
-        "path": "/home/ncrmro/repos/ncrmro/plouton",
-        "type": "path"
+        "type": "git",
+        "url": "ssh://forgejo@git.ncrmro.com:2222/ncrmro/plouton.git"
       }
     },
     "pre-commit": {

--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,11 @@
       inputs.llm-agents.follows = "llm-agents";
     };
 
-    # Plouton — FastAPI + Astro SPA, hosted on ocean.
+    # Plouton — FastAPI + Astro SPA, hosted on ocean. Use the canonical
+    # Forgejo main branch so every host can evaluate the same lock without
+    # requiring an identical local checkout at ~/repos/ncrmro/plouton.
     plouton = {
-      url = "path:/home/ncrmro/repos/ncrmro/plouton";
+      url = "git+ssh://forgejo@git.ncrmro.com:2222/ncrmro/plouton.git";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -163,7 +165,12 @@
           # mkSystemFlake-managed host (maia, ncrmro-laptop, mercury,
           # ocean, ncrmro-workstation); catalystPrimary is wired
           # manually below and unaffected.
-          ({ ... }: { keystone.os.zram.enable = true; })
+          (
+            { ... }:
+            {
+              keystone.os.zram.enable = true;
+            }
+          )
         ];
         hosts = {
           maia = {


### PR DESCRIPTION
## Summary\n- switch plouton from a local path input to the canonical Forgejo git remote\n- update flake.lock to plouton main rev 1e1979c\n- removes host-local path hash drift so workstation/laptop/ocean can evaluate the same ks-config lock\n\n## Verification\n- nix eval .#nixosConfigurations.ncrmro-workstation.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => false\n- nix eval .#nixosConfigurations.ncrmro-laptop.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => false\n- nix eval .#nixosConfigurations.ocean.config.\"home-manager\".users.ncrmro.keystone.notes.daily.enable => true\n- nix eval .#nixosConfigurations.ocean.config.systemd.sockets.systemd-journal-remote.listenStreams => ["", "127.0.0.1:19532"]\n\nNo closure builds were run; ks-host-sync says to ask before building.