### PR TITLE
fix(flake): fetch plouton LFS objects deterministically

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1775,6 +1775,7 @@
       },
       "locked": {
         "lastModified": 1780599732,
+        "lfs": true,
         "narHash": "sha256-YHExIkxC1doB770h25cTsulLXeCX8vqJDxB9AhCSPzY=",
         "ref": "refs/heads/main",
         "rev": "1e1979c1bf503760de62fb3076245b759c286847",
@@ -1783,6 +1784,7 @@
         "url": "ssh://forgejo@git.ncrmro.com:2222/ncrmro/plouton.git"
       },
       "original": {
+        "lfs": true,
         "type": "git",
         "url": "ssh://forgejo@git.ncrmro.com:2222/ncrmro/plouton.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
     # Forgejo main branch so every host can evaluate the same lock without
     # requiring an identical local checkout at ~/repos/ncrmro/plouton.
     plouton = {
-      url = "git+ssh://forgejo@git.ncrmro.com:2222/ncrmro/plouton.git";
+      url = "git+ssh://forgejo@git.ncrmro.com:2222/ncrmro/plouton.git?lfs=1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary
- mark the plouton flake input with `lfs=1` so Nix fetches the ElectronX PDF LFS object instead of host-dependent pointer/content state
- update `flake.lock` to record `lfs=true` while keeping the same plouton rev

## Verification
- `nix eval --json '.#nixosConfigurations.ncrmro-workstation.config.home-manager.users.ncrmro.keystone.notes.daily.enable'` -> `false`
- `nix eval --json '.#nixosConfigurations.ocean.config.home-manager.users.ncrmro.keystone.notes.daily.enable'` -> `true`
- `nix eval --json '.#nixosConfigurations.ocean.config.systemd.sockets.systemd-journal-remote.listenStreams'` -> `["","127.0.0.1:19532"]`
- ocean: `nix eval --refresh --json 'git+ssh://git@github.com/ncrmro/ks-config.git?ref=refs/heads/fix/plouton-lfs-input#nixosConfigurations.ocean.config.home-manager.users.ncrmro.keystone.notes.daily.enable'` -> `true`
- laptop: same branch eval for daily enable -> `false`
