### PR TITLE
fix(flake): lock vega from Forgejo SSH remote

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2359,17 +2359,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1780708581,
-        "narHash": "sha256-GAoZB1+o4ygC7fxC/DUNlSc294YuJ3rnlb0f8e0FH38=",
-        "ref": "refs/heads/feat/declarative-config",
-        "rev": "044e6940888d73ada57e2c52dd20f308247d5eaf",
-        "revCount": 67,
+        "lastModified": 1780876654,
+        "narHash": "sha256-koSL7qgAcLB1Wl//E6uKSPfUyHCAHPH2qxCaHm8coHE=",
+        "ref": "refs/heads/main",
+        "rev": "8672005745bd3f4145a1b9d01e7c6da8beda0ccb",
+        "revCount": 76,
         "type": "git",
-        "url": "file:///home/ncrmro/repos/ncrmro/worktrees/vega/feat/declarative-config"
+        "url": "ssh://forgejo@git.ncrmro.com:2222/ncrmro/vega.git"
       },
       "original": {
         "type": "git",
-        "url": "file:///home/ncrmro/repos/ncrmro/worktrees/vega/feat/declarative-config"
+        "url": "ssh://forgejo@git.ncrmro.com:2222/ncrmro/vega.git"
       }
     },
     "walker": {

--- a/flake.nix
+++ b/flake.nix
@@ -56,9 +56,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Vega — personal dashboard + MCP server, hosted on ocean.
+    # Vega — personal dashboard + MCP server, hosted on ocean. Use the
+    # canonical Forgejo main branch so every host can evaluate the same lock
+    # without requiring an identical local worktree.
     vega = {
-      url = "git+file:///home/ncrmro/repos/ncrmro/worktrees/vega/feat/declarative-config";
+      url = "git+ssh://forgejo@git.ncrmro.com:2222/ncrmro/vega.git";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.llm-agents.follows = "llm-agents";
     };


### PR DESCRIPTION
## Summary
- switch the Vega flake input from the host-local `git+file:///home/ncrmro/repos/ncrmro/worktrees/vega/feat/declarative-config` worktree to the canonical Forgejo SSH git URL
- refresh only the Vega lock to `vega@main` rev `8672005745bd3f4145a1b9d01e7c6da8beda0ccb`
- keep the Vega flake input for the `ks-vega` MCP client binary while the ocean Vega server itself continues to run from the container image

## Verification
- `nix eval --json '.#nixosConfigurations.ncrmro-workstation.config.home-manager.users.ncrmro.keystone.notes.daily.enable'` -> `false`
- `nix eval --json '.#nixosConfigurations.ncrmro-laptop.config.home-manager.users.ncrmro.keystone.notes.daily.enable'` -> `false`
- `nix eval --json '.#nixosConfigurations.ocean.config.home-manager.users.ncrmro.keystone.notes.daily.enable'` -> `true`
- laptop: `nix flake metadata --json --no-write-lock-file --refresh 'git+ssh://forgejo@git.ncrmro.com:2222/ncrmro/vega.git?rev=8672005745bd3f4145a1b9d01e7c6da8beda0ccb'` matched lock hash
- ocean: same Forgejo SSH metadata check matched lock hash

No closure builds or deploys run.
