### PR TITLE
feat(workstation): enable i2c for DDC/CI monitor control

### DIFF
--- a/hosts/workstation/default.nix
+++ b/hosts/workstation/default.nix
@@ -68,6 +68,7 @@
   users.users.ncrmro.extraGroups = [
     "render"
     "video"
+    "i2c"
   ];
 
   # Stalwart mail user password for himalaya
@@ -120,6 +121,7 @@
     alsa-utils
     lsof
     amdgpu_top
+    ddcutil
     lutris
     # llama-cpp from upstream flake with Vulkan support for AMD GPU acceleration
     inputs.llama-cpp.packages.${pkgs.stdenv.hostPlatform.system}.vulkan
@@ -133,6 +135,10 @@
   keystone.hardware.uhk.enable = true;
 
   hardware.ledger.enable = true;
+
+  # DDC/CI monitor control (ddcutil): loads i2c-dev and grants group i2c
+  # access to /dev/i2c-* so the Dell U5226KW input can be switched over I2C.
+  hardware.i2c.enable = true;
 
   hardware.graphics = {
     enable = true;


### PR DESCRIPTION
Enables `hardware.i2c` on the workstation only, so `ddcutil` can switch the Dell U5226KW's input source (VCP 0x60) over the DisplayPort aux I2C channel — see the spike at `notes/research/2026-07-11-dell-u5226kw-thunderbolt-input-switch/`.

- `hardware.i2c.enable = true` — loads `i2c-dev`, adds the udev rule granting group `i2c` access to `/dev/i2c-*`
- adds `ncrmro` to the `i2c` group
- adds `ddcutil` to workstation system packages

Verified: `nix eval` shows `hardware.i2c.enable = true` and the `i2c` group on `ncrmro-workstation`; `ncrmro-laptop` and `ocean` remain `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)